### PR TITLE
Rollup of small changes for Rapier

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -42,4 +42,4 @@ serde           = { version = "1.0", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 rand  = { version = "0.7", default-features = false }
-simba = { version = "0.1", features = [ "partial_fixed_point_support" ] }
+simba = { version = "0.2", features = [ "partial_fixed_point_support" ] }

--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -35,8 +35,8 @@ smallvec        = "1"
 slab            = "0.4"
 slotmap         = "0.4"
 petgraph        = "0.5"
-simba           = "0.1"
-nalgebra        = "0.21"
+simba           = "0.2"
+nalgebra        = "0.22"
 approx          = { version = "0.3", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 

--- a/build/ncollide2d/examples/cuboid2d.rs
+++ b/build/ncollide2d/examples/cuboid2d.rs
@@ -6,6 +6,6 @@ use ncollide2d::shape::Cuboid;
 fn main() {
     let cuboid = Cuboid::new(Vector2::new(2.0f32, 1.0));
 
-    assert!(cuboid.half_extents().x == 2.0);
-    assert!(cuboid.half_extents().y == 1.0);
+    assert!(cuboid.half_extents.x == 2.0);
+    assert!(cuboid.half_extents.y == 1.0);
 }

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -35,8 +35,8 @@ smallvec   = "1"
 slab       = "0.4"
 slotmap    = "0.4"
 petgraph   = "0.5"
-simba      = "0.1"
-nalgebra   = "0.21"
+simba      = "0.2"
+nalgebra   = "0.22"
 approx     = { version = "0.3", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 

--- a/build/ncollide3d/examples/cuboid3d.rs
+++ b/build/ncollide3d/examples/cuboid3d.rs
@@ -6,7 +6,7 @@ use ncollide3d::shape::Cuboid;
 fn main() {
     let cuboid = Cuboid::new(Vector3::new(2.0f32, 1.0, 3.0));
 
-    assert!(cuboid.half_extents().x == 2.0);
-    assert!(cuboid.half_extents().y == 1.0);
-    assert!(cuboid.half_extents().z == 3.0);
+    assert!(cuboid.half_extents.x == 2.0);
+    assert!(cuboid.half_extents.y == 1.0);
+    assert!(cuboid.half_extents.z == 3.0);
 }

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -51,11 +51,20 @@ impl<N: RealField> AABB<N> {
         AABB { mins, maxs }
     }
 
-    /// Creates a new AABB from its scenter and its half-extents.
+    /// Creates a new AABB from its center and its half-extents.
     #[inline]
     pub fn from_half_extents(center: Point<N>, half_extents: Vector<N>) -> Self {
         Self::new(center - half_extents, center + half_extents)
     }
+
+    /// Creates a new AABB from a set of points.
+    pub fn from_points<'a, I>(pts: I) -> Self
+    where
+        I: IntoIterator<Item = &'a Point<N>>,
+    {
+        super::aabb_utils::local_point_cloud_aabb(pts)
+    }
+
     /// Reference to the AABB point with the smallest components along each axis.
     #[inline]
     #[deprecated(note = "use the `.mins` public field instead.")]
@@ -87,6 +96,12 @@ impl<N: RealField> AABB<N> {
     #[inline]
     pub fn extents(&self) -> Vector<N> {
         self.maxs - self.mins
+    }
+
+    /// Enlarges this AABB so it also contains the point `pt`.
+    pub fn take_point(&mut self, pt: Point<N>) {
+        self.mins = self.mins.coords.inf(&pt.coords).into();
+        self.maxs = self.maxs.coords.sup(&pt.coords).into();
     }
 
     /// Computes the AABB bounding `self` transformed by `m`.

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -33,10 +33,10 @@ where
 
 /// An Axis Aligned Bounding Box.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct AABB<N: RealField> {
-    mins: Point<N>,
-    maxs: Point<N>,
+    pub mins: Point<N>,
+    pub maxs: Point<N>,
 }
 
 impl<N: RealField> AABB<N> {
@@ -48,11 +48,7 @@ impl<N: RealField> AABB<N> {
     ///   must be smaller than the related components of `maxs`.
     #[inline]
     pub fn new(mins: Point<N>, maxs: Point<N>) -> AABB<N> {
-        // assert!(na::partial_le(&mins, &maxs));
-        AABB {
-            mins: mins,
-            maxs: maxs,
-        }
+        AABB { mins, maxs }
     }
 
     /// Creates a new AABB from its scenter and its half-extents.
@@ -60,15 +56,16 @@ impl<N: RealField> AABB<N> {
     pub fn from_half_extents(center: Point<N>, half_extents: Vector<N>) -> Self {
         Self::new(center - half_extents, center + half_extents)
     }
-
     /// Reference to the AABB point with the smallest components along each axis.
     #[inline]
+    #[deprecated(note = "use the `.mins` public field instead.")]
     pub fn mins(&self) -> &Point<N> {
         &self.mins
     }
 
     /// Reference to the AABB point with the biggest components along each axis.
     #[inline]
+    #[deprecated(note = "use the `.maxs` public field instead.")]
     pub fn maxs(&self) -> &Point<N> {
         &self.maxs
     }
@@ -106,7 +103,7 @@ impl<N: RealField> AABB<N> {
     #[inline]
     pub fn bounding_sphere(&self) -> BoundingSphere<N> {
         let center = self.center();
-        let rad = na::distance(self.mins(), self.maxs());
+        let rad = na::distance(&self.mins, &self.maxs);
 
         BoundingSphere::new(center, rad)
     }

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -51,6 +51,17 @@ impl<N: RealField> AABB<N> {
         AABB { mins, maxs }
     }
 
+    /// Creates an invalid AABB with `mins` components set to `N::max_values` and `maxs`components set to `-N::max_values`.
+    ///
+    /// This is often used as the initial values of some AABB merging algorithms.
+    #[inline]
+    pub fn new_invalid() -> Self {
+        Self::new(
+            Vector::repeat(N::max_value()).into(),
+            Vector::repeat(-N::max_value()).into(),
+        )
+    }
+
     /// Creates a new AABB from its center and its half-extents.
     #[inline]
     pub fn from_half_extents(center: Point<N>, half_extents: Vector<N>) -> Self {

--- a/src/bounding_volume/aabb_ball.rs
+++ b/src/bounding_volume/aabb_ball.rs
@@ -23,11 +23,11 @@ pub fn local_ball_aabb<N: RealField>(radius: N) -> AABB<N> {
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Ball<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        ball_aabb(&Point::from(m.translation.vector), self.radius())
+        ball_aabb(&Point::from(m.translation.vector), self.radius)
     }
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        local_ball_aabb(self.radius())
+        local_ball_aabb(self.radius)
     }
 }

--- a/src/bounding_volume/aabb_cuboid.rs
+++ b/src/bounding_volume/aabb_cuboid.rs
@@ -8,14 +8,14 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cuboid<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         let center = Point::from(m.translation.vector);
-        let ws_half_extents = m.absolute_transform_vector(self.half_extents());
+        let ws_half_extents = m.absolute_transform_vector(&self.half_extents);
 
         AABB::from_half_extents(center, ws_half_extents)
     }
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        let half_extents = Point::from(*self.half_extents());
+        let half_extents = Point::from(self.half_extents);
 
         AABB::new(-half_extents, half_extents)
     }

--- a/src/bounding_volume/aabb_segment.rs
+++ b/src/bounding_volume/aabb_segment.rs
@@ -1,8 +1,8 @@
-use crate::bounding_volume::{HasBoundingVolume, AABB};
 use crate::bounding_volume;
-use crate::shape::Segment;
+use crate::bounding_volume::{HasBoundingVolume, AABB};
 use crate::math::Matrix;
 use crate::math::{Point, Scalar, Vector};
+use crate::shape::Segment;
 
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Segment<N> {
     #[inline]
@@ -13,7 +13,6 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Segment<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        // SPEED: add `local_support_map_aabb` function to support map
-        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+        bounding_volume::local_support_map_aabb(self)
     }
 }

--- a/src/bounding_volume/aabb_support_map.rs
+++ b/src/bounding_volume/aabb_support_map.rs
@@ -15,8 +15,7 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cone<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        // SPEED: add `local_support_map_aabb` function to support map
-        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+        bounding_volume::local_support_map_aabb(self)
     }
 }
 
@@ -29,8 +28,7 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cylinder<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        // SPEED: add `local_support_map_aabb` function to support map
-        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+        bounding_volume::local_support_map_aabb(self)
     }
 }
 
@@ -42,8 +40,7 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Capsule<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        // SPEED: add `local_support_map_aabb` function to support map
-        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+        bounding_volume::local_support_map_aabb(self)
     }
 }
 
@@ -56,7 +53,6 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Segment<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        // SPEED: add `local_support_map_aabb` function to support map
-        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+        bounding_volume::local_support_map_aabb(self)
     }
 }

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -8,9 +8,9 @@ use na::RealField;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        let a = m.transform_point(self.a()).coords;
-        let b = m.transform_point(self.b()).coords;
-        let c = m.transform_point(self.c()).coords;
+        let a = m.transform_point(&self.a).coords;
+        let b = m.transform_point(&self.b).coords;
+        let c = m.transform_point(&self.c).coords;
 
         let mut min = unsafe { Point::new_uninitialized() };
         let mut max = unsafe { Point::new_uninitialized() };
@@ -25,9 +25,9 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> AABB<N> {
-        let a = self.a().coords;
-        let b = self.b().coords;
-        let c = self.c().coords;
+        let a = self.a.coords;
+        let b = self.b.coords;
+        let c = self.c.coords;
 
         let mut min = unsafe { Point::new_uninitialized() };
         let mut max = unsafe { Point::new_uninitialized() };

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -42,6 +42,7 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "dim3")]
 mod test {
     use crate::{
         bounding_volume::support_map_aabb,

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -30,6 +30,31 @@ where
     AABB::new(Point::from(min), Point::from(max))
 }
 
+/// Computes the AABB of an support mapped shape.
+pub fn local_support_map_aabb<N, G>(i: &G) -> AABB<N>
+where
+    N: RealField,
+    G: SupportMap<N>,
+{
+    let mut min = na::zero::<Vector<N>>();
+    let mut max = na::zero::<Vector<N>>();
+    let mut basis = na::zero::<Vector<N>>();
+
+    for d in 0..DIM {
+        // FIXME: this could be further improved iterating on `m`'s columns, and passing
+        // Id as the transformation matrix.
+        basis[d] = na::one();
+        max[d] = i.local_support_point(&basis)[d];
+
+        basis[d] = -na::one::<N>();
+        min[d] = i.local_support_point(&basis)[d];
+
+        basis[d] = na::zero();
+    }
+
+    AABB::new(Point::from(min), Point::from(max))
+}
+
 /// Computes the AABB of a set of points transformed by `m`.
 pub fn point_cloud_aabb<'a, N: RealField, I>(m: &Isometry<N>, pts: I) -> AABB<N>
 where

--- a/src/bounding_volume/bounding_sphere.rs
+++ b/src/bounding_volume/bounding_sphere.rs
@@ -30,7 +30,7 @@ where
 
 /// A Bounding Sphere.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct BoundingSphere<N: RealField> {
     center: Point<N>,
     radius: N,

--- a/src/bounding_volume/bounding_sphere_ball.rs
+++ b/src/bounding_volume/bounding_sphere_ball.rs
@@ -12,8 +12,6 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Ball<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let radius = self.radius();
-
-        BoundingSphere::new(Point::origin(), radius)
+        BoundingSphere::new(Point::origin(), self.radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_capsule.rs
+++ b/src/bounding_volume/bounding_sphere_capsule.rs
@@ -12,7 +12,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Capsule<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let radius = self.radius() + self.half_height();
+        let radius = self.radius + self.half_height;
 
         BoundingSphere::new(Point::origin(), radius)
     }

--- a/src/bounding_volume/bounding_sphere_cone.rs
+++ b/src/bounding_volume/bounding_sphere_cone.rs
@@ -13,8 +13,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cone<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let radius =
-            (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
+        let radius = (self.radius * self.radius + self.half_height * self.half_height).sqrt();
 
         BoundingSphere::new(Point::origin(), radius)
     }

--- a/src/bounding_volume/bounding_sphere_cuboid.rs
+++ b/src/bounding_volume/bounding_sphere_cuboid.rs
@@ -12,7 +12,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cuboid<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let radius = self.half_extents().norm();
+        let radius = self.half_extents.norm();
 
         BoundingSphere::new(Point::origin(), radius)
     }

--- a/src/bounding_volume/bounding_sphere_cylinder.rs
+++ b/src/bounding_volume/bounding_sphere_cylinder.rs
@@ -13,8 +13,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cylinder<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let radius =
-            (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
+        let radius = (self.radius * self.radius + self.half_height * self.half_height).sqrt();
 
         BoundingSphere::new(Point::origin(), radius)
     }

--- a/src/bounding_volume/bounding_sphere_segment.rs
+++ b/src/bounding_volume/bounding_sphere_segment.rs
@@ -13,7 +13,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Segment<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let pts = [*self.a(), *self.b()];
+        let pts = [self.a, self.b];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 
         BoundingSphere::new(center, radius)

--- a/src/bounding_volume/bounding_sphere_triangle.rs
+++ b/src/bounding_volume/bounding_sphere_triangle.rs
@@ -13,7 +13,7 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Triangle<N> {
 
     #[inline]
     fn local_bounding_volume(&self) -> BoundingSphere<N> {
-        let pts = [*self.a(), *self.b(), *self.c()];
+        let pts = [self.a, self.b, self.c];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 
         BoundingSphere::new(center, radius)

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -6,7 +6,7 @@ pub use self::spatialized_normal_cone::SpatializedNormalCone;
 pub use crate::bounding_volume::aabb::{aabb, local_aabb, AABB};
 pub use crate::bounding_volume::aabb_ball::ball_aabb;
 pub use crate::bounding_volume::aabb_utils::{
-    local_point_cloud_aabb, point_cloud_aabb, support_map_aabb,
+    local_point_cloud_aabb, local_support_map_aabb, point_cloud_aabb, support_map_aabb,
 };
 #[doc(inline)]
 pub use crate::bounding_volume::bounding_sphere::{
@@ -35,7 +35,6 @@ mod aabb_plane;
 mod aabb_polyline;
 mod aabb_shape;
 mod aabb_support_map;
-#[cfg(feature = "dim3")]
 mod aabb_triangle;
 #[cfg(feature = "dim3")]
 mod aabb_trimesh;
@@ -60,7 +59,6 @@ mod bounding_sphere_plane;
 mod bounding_sphere_polyline;
 mod bounding_sphere_segment;
 mod bounding_sphere_shape;
-#[cfg(feature = "dim3")]
 mod bounding_sphere_triangle;
 #[cfg(feature = "dim3")]
 mod bounding_sphere_trimesh;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ macro_rules! try_ret {
 const NOT_REGISTERED_ERROR: &'static str =
     "This collision object has not been registered into a world (proxy indexes are None).";
 
-#[deprecated = "Use the `pipeline` module instead."]
+#[deprecated = "use the `pipeline` module instead."]
 pub use crate::pipeline::{broad_phase, narrow_phase, world};
 
 pub mod bounding_volume;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,10 @@ extern crate approx;
 extern crate downcast_rs;
 #[macro_use]
 extern crate bitflags;
-extern crate nalgebra as na;
 extern crate num_traits as num;
 
-pub use nalgebra;
-pub use simba;
+pub extern crate nalgebra as na;
+pub extern crate simba;
 
 macro_rules! try_ret {
     ($val: expr) => {

--- a/src/pipeline/narrow_phase/contact_generator/ball_ball_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/ball_ball_manifold_generator.rs
@@ -54,8 +54,8 @@ impl<N: RealField> ContactManifoldGenerator<N> for BallBallManifoldGenerator<N> 
                     Point::origin(),
                     NeighborhoodGeometry::Point,
                 );
-                kinematic.set_dilation1(a.radius());
-                kinematic.set_dilation2(b.radius());
+                kinematic.set_dilation1(a.radius);
+                kinematic.set_dilation2(b.radius);
 
                 let _ = manifold.push(contact, kinematic, Point::origin(), proc1, proc2);
             }

--- a/src/pipeline/narrow_phase/contact_generator/ball_convex_polyhedron_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/ball_convex_polyhedron_manifold_generator.rs
@@ -53,10 +53,10 @@ impl<N: RealField> BallConvexPolyhedronManifoldGenerator<N> {
             let normal;
             if let Some((dir, dist)) = Unit::try_new_and_get(dpt, N::default_epsilon()) {
                 if proj.is_inside {
-                    depth = dist + ball.radius();
+                    depth = dist + ball.radius;
                     normal = -dir;
                 } else {
-                    depth = -dist + ball.radius();
+                    depth = -dist + ball.radius;
                     normal = dir;
                 }
             } else {
@@ -72,18 +72,18 @@ impl<N: RealField> BallConvexPolyhedronManifoldGenerator<N> {
             if depth >= -prediction.linear() {
                 let mut kinematic = ContactKinematic::new();
                 let f1 = FeatureId::Face(0);
-                let world1 = ball_center + normal.into_inner() * ball.radius();
+                let world1 = ball_center + normal.into_inner() * ball.radius;
 
                 let contact;
 
                 if !self.flip {
                     contact = Contact::new(world1, world2, normal, depth);
                     kinematic.set_approx1(f1, Point::origin(), NeighborhoodGeometry::Point);
-                    kinematic.set_dilation1(ball.radius());
+                    kinematic.set_dilation1(ball.radius);
                 } else {
                     contact = Contact::new(world2, world1, -normal, depth);
                     kinematic.set_approx2(f1, Point::origin(), NeighborhoodGeometry::Point);
-                    kinematic.set_dilation2(ball.radius());
+                    kinematic.set_dilation2(ball.radius);
                 }
 
                 let local2 = m2.inverse_transform_point(&world2);

--- a/src/pipeline/narrow_phase/contact_generator/capsule_capsule_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/capsule_capsule_manifold_generator.rs
@@ -36,7 +36,7 @@ impl<N: RealField> CapsuleCapsuleManifoldGenerator<N> {
         let segment2 = g2.segment();
 
         let mut prediction = prediction.clone();
-        let new_linear_prediction = prediction.linear() + g1.radius() + g2.radius();
+        let new_linear_prediction = prediction.linear() + g1.radius + g2.radius;
         prediction.set_linear(new_linear_prediction);
 
         // Update all collisions

--- a/src/pipeline/narrow_phase/contact_generator/capsule_shape_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/capsule_shape_manifold_generator.rs
@@ -34,7 +34,7 @@ impl<N: RealField> CapsuleShapeManifoldGenerator<N> {
     ) -> bool {
         let segment = g1.segment();
         let mut prediction = prediction.clone();
-        let new_linear_prediction = prediction.linear() + g1.radius();
+        let new_linear_prediction = prediction.linear() + g1.radius;
         prediction.set_linear(new_linear_prediction);
 
         if self.sub_detector.is_none() {

--- a/src/pipeline/narrow_phase/contact_generator/plane_ball_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/plane_ball_manifold_generator.rs
@@ -39,16 +39,16 @@ impl<N: RealField> PlaneBallManifoldGenerator<N> {
         flip: bool,
     ) -> bool {
         if let (Some(plane), Some(ball)) = (g1.as_shape::<Plane<N>>(), g2.as_shape::<Ball<N>>()) {
-            let plane_normal = m1 * plane.normal();
+            let plane_normal = m1 * plane.normal;
             let plane_center = Point::from(m1.translation.vector);
 
             let ball_center = Point::from(m2.translation.vector);
             let dist = (ball_center - plane_center).dot(plane_normal.as_ref());
-            let depth = -dist + ball.radius();
+            let depth = -dist + ball.radius;
 
             if depth > -prediction.linear() {
                 let world1 = ball_center + *plane_normal * (-dist);
-                let world2 = ball_center + *plane_normal * (-ball.radius());
+                let world2 = ball_center + *plane_normal * (-ball.radius);
 
                 let local1 = m1.inverse_transform_point(&world1);
                 let local2 = Point::origin();
@@ -59,18 +59,18 @@ impl<N: RealField> PlaneBallManifoldGenerator<N> {
                 let contact;
 
                 let approx_ball = NeighborhoodGeometry::Point;
-                let approx_plane = NeighborhoodGeometry::Plane(*plane.normal());
+                let approx_plane = NeighborhoodGeometry::Plane(plane.normal);
 
                 if !flip {
                     contact = Contact::new(world1, world2, plane_normal, depth);
                     kinematic.set_approx1(f1, local1, approx_plane);
                     kinematic.set_approx2(f2, local2, approx_ball);
-                    kinematic.set_dilation2(ball.radius());
+                    kinematic.set_dilation2(ball.radius);
                     let _ = manifold.push(contact, kinematic, Point::origin(), proc1, proc2);
                 } else {
                     contact = Contact::new(world2, world1, -plane_normal, depth);
                     kinematic.set_approx1(f2, local2, approx_ball);
-                    kinematic.set_dilation1(ball.radius());
+                    kinematic.set_dilation1(ball.radius);
                     kinematic.set_approx2(f1, local1, approx_plane);
                     let _ = manifold.push(contact, kinematic, Point::origin(), proc2, proc1);
                 }

--- a/src/pipeline/narrow_phase/contact_generator/plane_convex_polyhedron_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/plane_convex_polyhedron_manifold_generator.rs
@@ -39,7 +39,7 @@ impl<N: RealField> PlaneConvexPolyhedronManifoldGenerator<N> {
         flip: bool,
     ) -> bool {
         if let (Some(plane), Some(cp)) = (g1.as_shape::<Plane<N>>(), g2.as_convex_polyhedron()) {
-            let plane_normal = m1 * plane.normal();
+            let plane_normal = m1 * plane.normal;
             let plane_center = Point::from(m1.translation.vector);
 
             cp.support_face_toward(m2, &-plane_normal, poly_feature);
@@ -57,7 +57,7 @@ impl<N: RealField> PlaneConvexPolyhedronManifoldGenerator<N> {
                     let mut kinematic = ContactKinematic::new();
                     let contact;
 
-                    let approx_plane = NeighborhoodGeometry::Plane(*plane.normal());
+                    let approx_plane = NeighborhoodGeometry::Plane(plane.normal);
                     let approx2 = NeighborhoodGeometry::Point;
 
                     if !flip {

--- a/src/pipeline/narrow_phase/contact_generator/trimesh_trimesh_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/trimesh_trimesh_manifold_generator.rs
@@ -107,7 +107,7 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                 let mut penetration_dir = Vector::y_axis();
 
                 // First, test normals.
-                let proj1 = t1.a().coords.dot(&n1);
+                let proj1 = t1.a.coords.dot(&n1);
                 let mut interval1 = (proj1, proj1);
                 let interval2 = t2.extents_on_dir(&n1);
 
@@ -125,7 +125,7 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                     break;
                 }
 
-                let proj2 = t2.a().coords.dot(&n2);
+                let proj2 = t2.a.coords.dot(&n2);
                 let mut interval2 = (proj2, proj2);
                 let interval1 = t1.extents_on_dir(&n2);
 
@@ -291,8 +291,8 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                     let seg2 = Segment::new(m12 * pts2[e2.indices.x], m12 * pts2[e2.indices.y]);
 
                     let locs = query::closest_points_segment_segment_with_locations_nD(
-                        (seg1.a(), seg1.b()),
-                        (seg2.a(), seg2.b()),
+                        (&seg1.a, &seg1.b),
+                        (&seg2.a, &seg2.b),
                     );
                     let p1 = seg1.point_at(&locs.0);
                     let p2 = seg2.point_at(&locs.1);
@@ -439,7 +439,7 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                     }
                 }
 
-                let dpt = p1 - t2.a();
+                let dpt = p1 - t2.a;
                 let dist = dpt.dot(&n2);
 
                 if dist >= N::zero()
@@ -483,7 +483,7 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                     }
                 }
 
-                let dpt = p2 - t1.a();
+                let dpt = p2 - t1.a;
                 let dist = dpt.dot(&n1);
 
                 if dist >= N::zero()
@@ -500,7 +500,7 @@ impl<N: RealField> TriMeshTriMeshManifoldGenerator<N> {
                     let mut kinematic = ContactKinematic::new();
                     kinematic.set_approx1(
                         FeatureId::Face(i1),
-                        *t1.a(),
+                        t1.a,
                         NeighborhoodGeometry::Plane(n1),
                     );
                     kinematic.set_approx2(

--- a/src/query/algorithms/minkowski_sampling.rs
+++ b/src/query/algorithms/minkowski_sampling.rs
@@ -34,7 +34,7 @@ where
     let mut min_dist = Bounded::max_value();
 
     Vector<N>::sample_sphere(|sample: Vector<N>| {
-        let support = cso.support_point(&Isometry::identity(), &sample);
+        let support = cso.local_support_point( &sample);
         let distance = sample.dot(&support.coords);
 
         if distance < min_dist {

--- a/src/query/algorithms/special_support_maps.rs
+++ b/src/query/algorithms/special_support_maps.rs
@@ -16,6 +16,16 @@ impl<N: RealField> SupportMap<N> for ConstantOrigin {
     fn support_point_toward(&self, _: &Isometry<N>, _: &Unit<Vector<N>>) -> Point<N> {
         Point::origin()
     }
+
+    #[inline]
+    fn local_support_point(&self, _: &Vector<N>) -> Point<N> {
+        Point::origin()
+    }
+
+    #[inline]
+    fn local_support_point_toward(&self, _: &Unit<Vector<N>>) -> Point<N> {
+        Point::origin()
+    }
 }
 
 /// The Minkowski sum of a shape and a ball.
@@ -35,5 +45,15 @@ impl<'a, N: RealField, S: ?Sized + SupportMap<N>> SupportMap<N> for DilatedShape
     #[inline]
     fn support_point_toward(&self, m: &Isometry<N>, dir: &Unit<Vector<N>>) -> Point<N> {
         self.shape.support_point_toward(m, dir) + **dir * self.radius
+    }
+
+    #[inline]
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        self.local_support_point_toward(&Unit::new_normalize(*dir))
+    }
+
+    #[inline]
+    fn local_support_point_toward(&self, dir: &Unit<Vector<N>>) -> Point<N> {
+        self.shape.local_support_point_toward(dir) + **dir * self.radius
     }
 }

--- a/src/query/closest_points/closest_points_ball_ball.rs
+++ b/src/query/closest_points/closest_points_ball_ball.rs
@@ -17,8 +17,8 @@ pub fn closest_points_ball_ball<N: RealField>(
         "The proximity margin must be positive or null."
     );
 
-    let r1 = b1.radius();
-    let r2 = b2.radius();
+    let r1 = b1.radius;
+    let r2 = b2.radius;
     let delta_pos = *center2 - *center1;
     let distance = delta_pos.norm();
     let sum_radius = r1 + r2;

--- a/src/query/closest_points/closest_points_composite_shape_shape.rs
+++ b/src/query/closest_points/closest_points_composite_shape_shape.rs
@@ -96,8 +96,8 @@ where
     ) -> BestFirstVisitStatus<N, Self::Result> {
         // Compute the minkowski sum of the two AABBs.
         let msum = AABB::new(
-            *bv.mins() + self.msum_shift + (-self.msum_margin),
-            *bv.maxs() + self.msum_shift + self.msum_margin,
+            bv.mins + self.msum_shift + (-self.msum_margin),
+            bv.maxs + self.msum_shift + self.msum_margin,
         );
 
         let dist = msum.distance_to_point(&Isometry::identity(), &Point::origin(), true);

--- a/src/query/closest_points/closest_points_plane_support_map.rs
+++ b/src/query/closest_points/closest_points_plane_support_map.rs
@@ -18,7 +18,7 @@ pub fn closest_points_plane_support_map<N: RealField, G: ?Sized + SupportMap<N>>
         "The proximity margin must be positive or null."
     );
 
-    let plane_normal = mplane * plane.normal();
+    let plane_normal = mplane * plane.normal;
     let plane_center = Point::from(mplane.translation.vector);
     let deepest = other.support_point(mother, &-plane_normal);
 

--- a/src/query/closest_points/closest_points_segment_segment.rs
+++ b/src/query/closest_points/closest_points_segment_segment.rs
@@ -37,7 +37,7 @@ pub fn closest_points_segment_segment_with_locations<N: RealField>(
     let seg1 = seg1.transformed(m1);
     let seg2 = seg2.transformed(m2);
 
-    closest_points_segment_segment_with_locations_nD((seg1.a(), seg1.b()), (seg2.a(), seg2.b()))
+    closest_points_segment_segment_with_locations_nD((&seg1.a, &seg1.b), (&seg2.a, &seg2.b))
 }
 
 /// Segment-segment closest points computation in an arbitrary dimension.

--- a/src/query/contact/contact_ball_ball.rs
+++ b/src/query/contact/contact_ball_ball.rs
@@ -12,8 +12,8 @@ pub fn contact_ball_ball<N: RealField>(
     b2: &Ball<N>,
     prediction: N,
 ) -> Option<Contact<N>> {
-    let r1 = b1.radius();
-    let r2 = b2.radius();
+    let r1 = b1.radius;
+    let r2 = b2.radius;
     let delta_pos = *center2 - *center1;
     let distance_squared = delta_pos.norm_squared();
     let sum_radius = r1 + r2;

--- a/src/query/contact/contact_ball_convex_polyhedron.rs
+++ b/src/query/contact/contact_ball_convex_polyhedron.rs
@@ -33,10 +33,10 @@ pub fn contact_ball_convex_polyhedron<N: RealField>(
     let normal;
     if let Some((dir, dist)) = Unit::try_new_and_get(dpt, N::default_epsilon()) {
         if proj.is_inside {
-            depth = dist + ball1.radius();
+            depth = dist + ball1.radius;
             normal = -dir;
         } else {
-            depth = -dist + ball1.radius();
+            depth = -dist + ball1.radius;
             normal = dir;
         }
     } else {
@@ -50,7 +50,7 @@ pub fn contact_ball_convex_polyhedron<N: RealField>(
     }
 
     if depth >= -prediction {
-        let world1 = ball_center1 + normal.into_inner() * ball1.radius();
+        let world1 = ball_center1 + normal.into_inner() * ball1.radius;
         return Some(Contact::new(world1, world2, normal, depth));
     }
 

--- a/src/query/contact/contact_plane_support_map.rs
+++ b/src/query/contact/contact_plane_support_map.rs
@@ -11,7 +11,7 @@ pub fn contact_plane_support_map<N: RealField, G: ?Sized + SupportMap<N>>(
     other: &G,
     prediction: N,
 ) -> Option<Contact<N>> {
-    let plane_normal = mplane * plane.normal();
+    let plane_normal = mplane * plane.normal;
     let plane_center = Point::from(mplane.translation.vector);
     let deepest = other.support_point_toward(mother, &-plane_normal);
 

--- a/src/query/distance/distance_ball_ball.rs
+++ b/src/query/distance/distance_ball_ball.rs
@@ -10,8 +10,8 @@ pub fn distance_ball_ball<N: RealField>(
     center2: &Point<N>,
     b2: &Ball<N>,
 ) -> N {
-    let r1 = b1.radius();
-    let r2 = b2.radius();
+    let r1 = b1.radius;
+    let r2 = b2.radius;
     let delta_pos = *center2 - *center1;
     let distance_squared = delta_pos.norm_squared();
     let sum_radius = r1 + r2;

--- a/src/query/distance/distance_composite_shape_shape.rs
+++ b/src/query/distance/distance_composite_shape_shape.rs
@@ -74,8 +74,8 @@ where
     ) -> BestFirstVisitStatus<N, Self::Result> {
         // Compute the minkowski sum of the two AABBs.
         let msum = AABB::new(
-            *bv.mins() + self.msum_shift + (-self.msum_margin),
-            *bv.maxs() + self.msum_shift + self.msum_margin,
+            bv.mins + self.msum_shift + (-self.msum_margin),
+            bv.maxs + self.msum_shift + self.msum_margin,
         );
 
         let dist = msum.distance_to_point(&Isometry::identity(), &Point::origin(), true);

--- a/src/query/distance/distance_plane_support_map.rs
+++ b/src/query/distance/distance_plane_support_map.rs
@@ -10,7 +10,7 @@ pub fn distance_plane_support_map<N: RealField, G: ?Sized + SupportMap<N>>(
     mother: &Isometry<N>,
     other: &G,
 ) -> N {
-    let plane_normal = mplane * plane.normal();
+    let plane_normal = mplane * plane.normal;
     let plane_center = Point::from(mplane.translation.vector);
     let deepest = other.support_point_toward(mother, &-plane_normal);
 

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -13,8 +13,8 @@ impl<N: RealField> AABB<N> {
         solid: bool,
     ) -> (bool, Point<N>, Vector<N>) {
         let ls_pt = m.inverse_transform_point(pt);
-        let mins_pt = *self.mins() - ls_pt;
-        let pt_maxs = ls_pt - *self.maxs();
+        let mins_pt = self.mins - ls_pt;
+        let pt_maxs = ls_pt - self.maxs;
         let shift = mins_pt.sup(&na::zero()) - pt_maxs.sup(&na::zero());
 
         let inside = shift.is_zero();
@@ -91,10 +91,10 @@ impl<N: RealField> PointQuery<N> for AABB<N> {
 
         if nzero_shifts == DIM {
             for i in 0..DIM {
-                if ls_pt[i] > self.maxs()[i] - N::default_epsilon() {
+                if ls_pt[i] > self.maxs[i] - N::default_epsilon() {
                     return (proj, FeatureId::Face(i));
                 }
-                if ls_pt[i] <= self.mins()[i] + N::default_epsilon() {
+                if ls_pt[i] <= self.mins[i] + N::default_epsilon() {
                     return (proj, FeatureId::Face(i + DIM));
                 }
             }
@@ -137,8 +137,8 @@ impl<N: RealField> PointQuery<N> for AABB<N> {
     #[inline]
     fn distance_to_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> N {
         let ls_pt = m.inverse_transform_point(pt);
-        let mins_pt = *self.mins() - ls_pt;
-        let pt_maxs = ls_pt - *self.maxs();
+        let mins_pt = self.mins - ls_pt;
+        let pt_maxs = ls_pt - self.maxs;
         let shift = mins_pt.sup(&pt_maxs).sup(&na::zero());
 
         if solid || !shift.is_zero() {

--- a/src/query/point/point_ball.rs
+++ b/src/query/point/point_ball.rs
@@ -11,12 +11,12 @@ impl<N: RealField> PointQuery<N> for Ball<N> {
         let ls_pt = m.inverse_transform_point(pt);
         let distance_squared = ls_pt.coords.norm_squared();
 
-        let inside = distance_squared <= self.radius() * self.radius();
+        let inside = distance_squared <= self.radius * self.radius;
 
         if inside && solid {
             PointProjection::new(true, *pt)
         } else {
-            let ls_proj = Point::from(ls_pt.coords * (self.radius() / distance_squared.sqrt()));
+            let ls_proj = Point::from(ls_pt.coords * (self.radius / distance_squared.sqrt()));
             PointProjection::new(inside, m * ls_proj)
         }
     }
@@ -32,7 +32,7 @@ impl<N: RealField> PointQuery<N> for Ball<N> {
 
     #[inline]
     fn distance_to_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> N {
-        let dist = m.inverse_transform_point(pt).coords.norm() - self.radius();
+        let dist = m.inverse_transform_point(pt).coords.norm() - self.radius;
 
         if solid && dist < na::zero() {
             na::zero()
@@ -43,6 +43,6 @@ impl<N: RealField> PointQuery<N> for Ball<N> {
 
     #[inline]
     fn contains_point(&self, m: &Isometry<N>, pt: &Point<N>) -> bool {
-        m.inverse_transform_point(pt).coords.norm_squared() <= self.radius() * self.radius()
+        m.inverse_transform_point(pt).coords.norm_squared() <= self.radius * self.radius
     }
 }

--- a/src/query/point/point_capsule.rs
+++ b/src/query/point/point_capsule.rs
@@ -7,17 +7,17 @@ impl<N: RealField> PointQuery<N> for Capsule<N> {
     #[inline]
     fn project_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> PointProjection<N> {
         let mut y = Point::origin();
-        y[1] = self.half_height();
+        y[1] = self.half_height;
         let seg = Segment::new(-y, y);
         let proj = seg.project_point(m, pt, solid);
         let dproj = *pt - proj.point;
 
         if let Some((dir, dist)) = Unit::try_new_and_get(dproj, N::default_epsilon()) {
-            let inside = dist <= self.radius();
+            let inside = dist <= self.radius;
             if solid && inside {
                 PointProjection::new(true, *pt)
             } else {
-                PointProjection::new(inside, proj.point + dir.into_inner() * self.radius())
+                PointProjection::new(inside, proj.point + dir.into_inner() * self.radius)
             }
         } else {
             if solid {
@@ -26,7 +26,7 @@ impl<N: RealField> PointQuery<N> for Capsule<N> {
                 let mut dir: Vector<N> = na::zero();
                 dir[1] = na::one();
                 dir = m * dir;
-                PointProjection::new(true, proj.point + dir * self.radius())
+                PointProjection::new(true, proj.point + dir * self.radius)
             }
         }
     }

--- a/src/query/point/point_cuboid.rs
+++ b/src/query/point/point_cuboid.rs
@@ -7,8 +7,8 @@ use na::RealField;
 impl<N: RealField> PointQuery<N> for Cuboid<N> {
     #[inline]
     fn project_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> PointProjection<N> {
-        let dl = Point::origin() + (-*self.half_extents());
-        let ur = Point::origin() + *self.half_extents();
+        let dl = Point::origin() + (-self.half_extents);
+        let ur = Point::origin() + self.half_extents;
         AABB::new(dl, ur).project_point(m, pt, solid)
     }
 
@@ -18,22 +18,22 @@ impl<N: RealField> PointQuery<N> for Cuboid<N> {
         m: &Isometry<N>,
         pt: &Point<N>,
     ) -> (PointProjection<N>, FeatureId) {
-        let dl = Point::origin() + (-*self.half_extents());
-        let ur = Point::origin() + *self.half_extents();
+        let dl = Point::origin() + (-self.half_extents);
+        let ur = Point::origin() + self.half_extents;
         AABB::new(dl, ur).project_point_with_feature(m, pt)
     }
 
     #[inline]
     fn distance_to_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> N {
-        let dl = Point::origin() + (-*self.half_extents());
-        let ur = Point::origin() + *self.half_extents();
+        let dl = Point::origin() + (-self.half_extents);
+        let ur = Point::origin() + self.half_extents;
         AABB::new(dl, ur).distance_to_point(m, pt, solid)
     }
 
     #[inline]
     fn contains_point(&self, m: &Isometry<N>, pt: &Point<N>) -> bool {
-        let dl = Point::origin() + (-*self.half_extents());
-        let ur = Point::origin() + *self.half_extents();
+        let dl = Point::origin() + (-self.half_extents);
+        let ur = Point::origin() + self.half_extents;
         AABB::new(dl, ur).contains_point(m, pt)
     }
 }

--- a/src/query/point/point_plane.rs
+++ b/src/query/point/point_plane.rs
@@ -7,14 +7,14 @@ impl<N: RealField> PointQuery<N> for Plane<N> {
     #[inline]
     fn project_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> PointProjection<N> {
         let ls_pt = m.inverse_transform_point(pt);
-        let d = self.normal().dot(&ls_pt.coords);
+        let d = self.normal.dot(&ls_pt.coords);
 
         let inside = d <= na::zero();
 
         if inside && solid {
             PointProjection::new(true, *pt)
         } else {
-            PointProjection::new(inside, *pt + (-*self.normal().as_ref() * d))
+            PointProjection::new(inside, *pt + (-*self.normal * d))
         }
     }
 
@@ -30,7 +30,7 @@ impl<N: RealField> PointQuery<N> for Plane<N> {
     #[inline]
     fn distance_to_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> N {
         let ls_pt = m.inverse_transform_point(pt);
-        let dist = self.normal().dot(&ls_pt.coords);
+        let dist = self.normal.dot(&ls_pt.coords);
 
         if dist < na::zero() && solid {
             na::zero()
@@ -44,6 +44,6 @@ impl<N: RealField> PointQuery<N> for Plane<N> {
     fn contains_point(&self, m: &Isometry<N>, pt: &Point<N>) -> bool {
         let ls_pt = m.inverse_transform_point(pt);
 
-        self.normal().dot(&ls_pt.coords) <= na::zero()
+        self.normal.dot(&ls_pt.coords) <= na::zero()
     }
 }

--- a/src/query/point/point_segment.rs
+++ b/src/query/point/point_segment.rs
@@ -56,8 +56,8 @@ impl<N: RealField> PointQueryWithLocation<N> for Segment<N> {
         _: bool,
     ) -> (PointProjection<N>, Self::Location) {
         let ls_pt = m.inverse_transform_point(pt);
-        let ab = *self.b() - *self.a();
-        let ap = ls_pt - *self.a();
+        let ab = self.b - self.a;
+        let ap = ls_pt - self.a;
         let ab_ap = ab.dot(&ap);
         let sqnab = ab.norm_squared();
         let _1 = na::one::<N>();
@@ -68,11 +68,11 @@ impl<N: RealField> PointQueryWithLocation<N> for Segment<N> {
         if ab_ap <= na::zero() {
             // Voronoï region of vertex 'a'.
             location = SegmentPointLocation::OnVertex(0);
-            proj = m * self.a();
+            proj = m * self.a;
         } else if ab_ap >= sqnab {
             // Voronoï region of vertex 'b'.
             location = SegmentPointLocation::OnVertex(1);
-            proj = m * self.b();
+            proj = m * self.b;
         } else {
             assert!(sqnab != na::zero());
 
@@ -80,7 +80,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Segment<N> {
             let u = ab_ap / sqnab;
             let bcoords = [_1 - u, u];
             location = SegmentPointLocation::OnEdge(bcoords);
-            proj = *self.a() + ab * u;
+            proj = self.a + ab * u;
             proj = m * proj;
         }
 

--- a/src/query/point/point_tetrahedron.rs
+++ b/src/query/point/point_tetrahedron.rs
@@ -40,10 +40,10 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
     ) -> (PointProjection<N>, Self::Location) {
         let p = m.inverse_transform_point(pt);
 
-        let ab = *self.b() - *self.a();
-        let ac = *self.c() - *self.a();
-        let ad = *self.d() - *self.a();
-        let ap = p - *self.a();
+        let ab = self.b - self.a;
+        let ac = self.c - self.a;
+        let ad = self.d - self.a;
+        let ap = p - self.a;
 
         /*
          * Voronoï regions of vertices.
@@ -56,13 +56,13 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         if ap_ab <= _0 && ap_ac <= _0 && ap_ad <= _0 {
             // Voronoï region of `a`.
-            let proj = PointProjection::new(false, m * self.a());
+            let proj = PointProjection::new(false, m * self.a);
             return (proj, TetrahedronPointLocation::OnVertex(0));
         }
 
-        let bc = *self.c() - *self.b();
-        let bd = *self.d() - *self.b();
-        let bp = p - *self.b();
+        let bc = self.c - self.b;
+        let bd = self.d - self.b;
+        let bp = p - self.b;
 
         let bp_bc = bp.dot(&bc);
         let bp_bd = bp.dot(&bd);
@@ -70,12 +70,12 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         if bp_bc <= _0 && bp_bd <= _0 && bp_ab >= _0 {
             // Voronoï region of `b`.
-            let proj = PointProjection::new(false, m * self.b());
+            let proj = PointProjection::new(false, m * self.b);
             return (proj, TetrahedronPointLocation::OnVertex(1));
         }
 
-        let cd = *self.d() - *self.c();
-        let cp = p - *self.c();
+        let cd = self.d - self.c;
+        let cp = p - self.c;
 
         let cp_ac = cp.dot(&ac);
         let cp_bc = cp.dot(&bc);
@@ -83,11 +83,11 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         if cp_cd <= _0 && cp_bc >= _0 && cp_ac >= _0 {
             // Voronoï region of `c`.
-            let proj = PointProjection::new(false, m * self.c());
+            let proj = PointProjection::new(false, m * self.c);
             return (proj, TetrahedronPointLocation::OnVertex(2));
         }
 
-        let dp = p - *self.d();
+        let dp = p - self.d;
 
         let dp_cd = dp.dot(&cd);
         let dp_bd = dp.dot(&bd);
@@ -95,7 +95,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         if dp_ad >= _0 && dp_bd >= _0 && dp_cd >= _0 {
             // Voronoï region of `d`.
-            let proj = PointProjection::new(false, m * self.d());
+            let proj = PointProjection::new(false, m * self.d);
             return (proj, TetrahedronPointLocation::OnVertex(3));
         }
 
@@ -157,15 +157,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         let nabc = ab.cross(&ac);
         let nabd = ab.cross(&ad);
         let (dabc, dabd, res) = check_edge(
-            0,
-            m,
-            self.a(),
-            self.b(),
-            &nabc,
-            &nabd,
-            &ap,
-            &ab,
-            ap_ab,
+            0, m, &self.a, &self.b, &nabc, &nabd, &ap, &ab, ap_ab,
             /*ap_ac, ap_ad,*/ bp_ab, /*, bp_ac, bp_ad*/
         );
         if let Some(res) = res {
@@ -181,15 +173,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         //            let cp_ad = cp_cd + cp_ac;
         let nacd = ac.cross(&ad);
         let (dacd, dacb, res) = check_edge(
-            1,
-            m,
-            self.a(),
-            self.c(),
-            &nacd,
-            &-nabc,
-            &ap,
-            &ac,
-            ap_ac,
+            1, m, &self.a, &self.c, &nacd, &-nabc, &ap, &ac, ap_ac,
             /*ap_ad, ap_ab,*/ cp_ac, /*, cp_ad, cp_ab*/
         );
         if let Some(res) = res {
@@ -204,15 +188,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         //            let dp_ac = dp_ad - dp_cd;
         //            let dp_ab = dp_ad - dp_bd;
         let (dadb, dadc, res) = check_edge(
-            2,
-            m,
-            self.a(),
-            self.d(),
-            &-nabd,
-            &-nacd,
-            &ap,
-            &ad,
-            ap_ad,
+            2, m, &self.a, &self.d, &-nabd, &-nacd, &ap, &ad, ap_ad,
             /*ap_ab, ap_ac,*/ dp_ad, /*, dp_ab, dp_ac*/
         );
         if let Some(res) = res {
@@ -228,15 +204,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         let nbcd = bc.cross(&bd);
         // NOTE: nabc = nbcd
         let (dbca, dbcd, res) = check_edge(
-            3,
-            m,
-            self.b(),
-            self.c(),
-            &nabc,
-            &nbcd,
-            &bp,
-            &bc,
-            bp_bc,
+            3, m, &self.b, &self.c, &nabc, &nbcd, &bp, &bc, bp_bc,
             /*-bp_ab, bp_bd,*/ cp_bc, /*, -cp_ab, cp_bd*/
         );
         if let Some(res) = res {
@@ -253,15 +221,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         // NOTE: nbdc = -nbcd
         // NOTE: nbda = nabd
         let (dbdc, dbda, res) = check_edge(
-            4,
-            m,
-            self.b(),
-            self.d(),
-            &-nbcd,
-            &nabd,
-            &bp,
-            &bd,
-            bp_bd,
+            4, m, &self.b, &self.d, &-nbcd, &nabd, &bp, &bd, bp_bd,
             /*bp_bc, -bp_ab,*/ dp_bd, /*, dp_bc, -dp_ab*/
         );
         if let Some(res) = res {
@@ -277,15 +237,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         // NOTE: ncda = nacd
         // NOTE: ncdb = nbcd
         let (dcda, dcdb, res) = check_edge(
-            5,
-            m,
-            self.c(),
-            self.d(),
-            &nacd,
-            &nbcd,
-            &cp,
-            &cd,
-            cp_cd,
+            5, m, &self.c, &self.d, &nacd, &nbcd, &cp, &cd, cp_cd,
             /*-cp_ac, -cp_bc,*/ dp_cd, /*, -dp_ac, -dp_bc*/
         );
         if let Some(res) = res {
@@ -355,19 +307,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         // Face abc.
         if let Some(res) = check_face(
-            0,
-            self.a(),
-            self.b(),
-            self.c(),
-            m,
-            &ap,
-            &bp,
-            &cp,
-            &ab,
-            &ac,
-            &ad,
-            dabc,
-            dbca,
+            0, &self.a, &self.b, &self.c, m, &ap, &bp, &cp, &ab, &ac, &ad, dabc, dbca,
             dacb,
             /*ap_ab, bp_ab, cp_ab,
             ap_ac, bp_ac, cp_ac*/
@@ -377,19 +317,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
 
         // Face abd.
         if let Some(res) = check_face(
-            1,
-            self.a(),
-            self.b(),
-            self.d(),
-            m,
-            &ap,
-            &bp,
-            &dp,
-            &ab,
-            &ad,
-            &ac,
-            dadb,
-            dabd,
+            1, &self.a, &self.b, &self.d, m, &ap, &bp, &dp, &ab, &ad, &ac, dadb, dabd,
             dbda,
             /*ap_ab, bp_ab, dp_ab,
             ap_ad, bp_ad, dp_ad*/
@@ -398,19 +326,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         }
         // Face acd.
         if let Some(res) = check_face(
-            2,
-            self.a(),
-            self.c(),
-            self.d(),
-            m,
-            &ap,
-            &cp,
-            &dp,
-            &ac,
-            &ad,
-            &ab,
-            dacd,
-            dcda,
+            2, &self.a, &self.c, &self.d, m, &ap, &cp, &dp, &ac, &ad, &ab, dacd, dcda,
             dadc,
             /*ap_ac, cp_ac, dp_ac,
             ap_ad, cp_ad, dp_ad*/
@@ -419,19 +335,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
         }
         // Face bcd.
         if let Some(res) = check_face(
-            3,
-            self.b(),
-            self.c(),
-            self.d(),
-            m,
-            &bp,
-            &cp,
-            &dp,
-            &bc,
-            &bd,
-            &-ab,
-            dbcd,
-            dcdb,
+            3, &self.b, &self.c, &self.d, m, &bp, &cp, &dp, &bc, &bd, &-ab, dbcd, dcdb,
             dbdc,
             /*bp_bc, cp_bc, dp_bc,
             bp_bd, cp_bd, dp_bd*/

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -64,9 +64,9 @@ impl<N: RealField> PointQueryWithLocation<N> for Triangle<N> {
         pt: &Point<N>,
         solid: bool,
     ) -> (PointProjection<N>, Self::Location) {
-        let a = *self.a();
-        let b = *self.b();
-        let c = *self.c();
+        let a = self.a;
+        let b = self.b;
+        let c = self.c;
         let p = m.inverse_transform_point(pt);
 
         let _1 = na::one::<N>();

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -250,7 +250,7 @@ impl<N: RealField> PointQueryWithLocation<N> for Triangle<N> {
             }
         }
 
-        // Special treatement if we work in 2d because in this case we really are inside of the
+        // Special treatment if we work in 2d because in this case we really are inside of the
         // object.
         if solid {
             (

--- a/src/query/proximity/proximity.rs
+++ b/src/query/proximity/proximity.rs
@@ -3,7 +3,7 @@
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Proximity {
     /// The two objects are intersecting.
-    Intersecting,
+    Intersecting = 0,
     /// The two objects are non-intersecting but closer than a given distance.
     WithinMargin,
     /// The two objects are non-intersecting and further than a given distance.

--- a/src/query/proximity/proximity_ball_ball.rs
+++ b/src/query/proximity/proximity_ball_ball.rs
@@ -17,8 +17,8 @@ pub fn proximity_ball_ball<N: RealField>(
         "The proximity margin must be positive or null."
     );
 
-    let r1 = b1.radius();
-    let r2 = b2.radius();
+    let r1 = b1.radius;
+    let r2 = b2.radius;
     let delta_pos = *center2 - *center1;
     let distance_squared = delta_pos.norm_squared();
     let sum_radius = r1 + r2;

--- a/src/query/proximity/proximity_composite_shape_shape.rs
+++ b/src/query/proximity/proximity_composite_shape_shape.rs
@@ -71,11 +71,11 @@ where
         CompositeShapeAgainstAnyInterfVisitor {
             msum_shift: -ls_aabb2.center().coords,
             msum_margin: ls_aabb2.half_extents(),
-            m1: m1,
-            g1: g1,
-            m2: m2,
-            g2: g2,
-            margin: margin,
+            m1,
+            g1,
+            m2,
+            g2,
+            margin,
         }
     }
 }
@@ -95,8 +95,8 @@ where
     ) -> BestFirstVisitStatus<N, Self::Result> {
         // Compute the minkowski sum of the two AABBs.
         let msum = AABB::new(
-            *bv.mins() + self.msum_shift + (-self.msum_margin),
-            *bv.maxs() + self.msum_shift + self.msum_margin,
+            bv.mins + self.msum_shift + (-self.msum_margin),
+            bv.maxs + self.msum_shift + self.msum_margin,
         );
 
         // Compute the distance to the origin.

--- a/src/query/proximity/proximity_plane_support_map.rs
+++ b/src/query/proximity/proximity_plane_support_map.rs
@@ -18,7 +18,7 @@ pub fn proximity_plane_support_map<N: RealField, G: ?Sized + SupportMap<N>>(
         "The proximity margin must be positive or null."
     );
 
-    let plane_normal = mplane * plane.normal();
+    let plane_normal = mplane * plane.normal;
     let plane_center = Point::from(mplane.translation.vector);
     let deepest = other.support_point_toward(mother, &-plane_normal);
 

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -19,14 +19,14 @@ impl<N: RealField> RayCast<N> for AABB<N> {
 
         for i in 0usize..DIM {
             if ls_ray.dir[i].is_zero() {
-                if ls_ray.origin[i] < self.mins()[i] || ls_ray.origin[i] > self.maxs()[i] {
+                if ls_ray.origin[i] < self.mins[i] || ls_ray.origin[i] > self.maxs[i] {
                     return None;
                 }
             } else {
                 let _1: N = na::one();
                 let denom = _1 / ls_ray.dir[i];
-                let mut inter_with_near_plane = (self.mins()[i] - ls_ray.origin[i]) * denom;
-                let mut inter_with_far_plane = (self.maxs()[i] - ls_ray.origin[i]) * denom;
+                let mut inter_with_near_plane = (self.mins[i] - ls_ray.origin[i]) * denom;
+                let mut inter_with_far_plane = (self.maxs[i] - ls_ray.origin[i]) * denom;
 
                 if inter_with_near_plane > inter_with_far_plane {
                     mem::swap(&mut inter_with_near_plane, &mut inter_with_far_plane)
@@ -146,8 +146,8 @@ fn do_toi_and_normal_and_uv_with_ray<N: RealField>(
 
         ray_aabb(aabb, &ls_ray, max_toi, solid).map(|(t, n, s)| {
             let pt = ls_ray.origin + ls_ray.dir * t;
-            let dpt = pt - *aabb.mins();
-            let scale = *aabb.maxs() - *aabb.mins();
+            let dpt = pt - aabb.mins;
+            let scale = aabb.maxs - aabb.mins;
             let id = s.abs();
             let gs_n = m * n;
             let feature = if s < 0 {
@@ -199,15 +199,15 @@ fn clip_line<N: RealField>(
 
     for i in 0usize..DIM {
         if dir[i].is_zero() {
-            if origin[i] < aabb.mins()[i] || origin[i] > aabb.maxs()[i] {
+            if origin[i] < aabb.mins[i] || origin[i] > aabb.maxs[i] {
                 return None;
             }
         } else {
             let _1: N = na::one();
             let denom = _1 / dir[i];
             let flip_sides;
-            let mut inter_with_near_plane = (aabb.mins()[i] - origin[i]) * denom;
-            let mut inter_with_far_plane = (aabb.maxs()[i] - origin[i]) * denom;
+            let mut inter_with_near_plane = (aabb.mins[i] - origin[i]) * denom;
+            let mut inter_with_far_plane = (aabb.maxs[i] - origin[i]) * denom;
 
             if inter_with_near_plane > inter_with_far_plane {
                 flip_sides = true;

--- a/src/query/ray/ray_ball.rs
+++ b/src/query/ray/ray_ball.rs
@@ -24,14 +24,9 @@ fn ball_uv<N: RealField>(normal: &Vector<N>) -> Point2<N> {
 impl<N: RealField> RayCast<N> for Ball<N> {
     #[inline]
     fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
-        ray_toi_with_ball(
-            &Point::from(m.translation.vector),
-            self.radius(),
-            ray,
-            solid,
-        )
-        .1
-        .filter(|toi| *toi <= max_toi)
+        ray_toi_with_ball(&Point::from(m.translation.vector), self.radius, ray, solid)
+            .1
+            .filter(|toi| *toi <= max_toi)
     }
 
     #[inline]
@@ -42,14 +37,9 @@ impl<N: RealField> RayCast<N> for Ball<N> {
         max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
-        ray_toi_and_normal_with_ball(
-            &Point::from(m.translation.vector),
-            self.radius(),
-            ray,
-            solid,
-        )
-        .1
-        .filter(|int| int.toi <= max_toi)
+        ray_toi_and_normal_with_ball(&Point::from(m.translation.vector), self.radius, ray, solid)
+            .1
+            .filter(|int| int.toi <= max_toi)
     }
 
     #[cfg(feature = "dim3")]
@@ -62,7 +52,7 @@ impl<N: RealField> RayCast<N> for Ball<N> {
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let center = Point::from(m.translation.vector);
-        let (inside, mut inter) = ray_toi_with_ball(&center, self.radius(), ray, solid);
+        let (inside, mut inter) = ray_toi_with_ball(&center, self.radius, ray, solid);
         inter = inter.filter(|toi| *toi <= max_toi);
 
         inter.map(|n| {

--- a/src/query/ray/ray_cuboid.rs
+++ b/src/query/ray/ray_cuboid.rs
@@ -7,8 +7,8 @@ use na::RealField;
 impl<N: RealField> RayCast<N> for Cuboid<N> {
     #[inline]
     fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
-        let dl = Point::from(-*self.half_extents());
-        let ur = Point::from(*self.half_extents());
+        let dl = Point::from(-self.half_extents);
+        let ur = Point::from(self.half_extents);
         AABB::new(dl, ur).toi_with_ray(m, ray, max_toi, solid)
     }
 
@@ -20,8 +20,8 @@ impl<N: RealField> RayCast<N> for Cuboid<N> {
         max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
-        let dl = Point::from(-*self.half_extents());
-        let ur = Point::from(*self.half_extents());
+        let dl = Point::from(-self.half_extents);
+        let ur = Point::from(self.half_extents);
         AABB::new(dl, ur).toi_and_normal_with_ray(m, ray, max_toi, solid)
     }
 
@@ -34,8 +34,8 @@ impl<N: RealField> RayCast<N> for Cuboid<N> {
         max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
-        let dl = Point::from(-*self.half_extents());
-        let ur = Point::from(*self.half_extents());
+        let dl = Point::from(-self.half_extents);
+        let ur = Point::from(self.half_extents);
         AABB::new(dl, ur).toi_and_normal_and_uv_with_ray(m, ray, max_toi, solid)
     }
 }

--- a/src/query/ray/ray_heightfield.rs
+++ b/src/query/ray/ray_heightfield.rs
@@ -45,7 +45,7 @@ impl<N: RealField> RayCast<N> for HeightField<N> {
             let (s, t) = query::closest_points_line_line_parameters(
                 &ray.origin,
                 &ray.dir,
-                seg.a(),
+                &seg.a,
                 &seg.scaled_direction(),
             );
             if s >= N::zero() && t >= N::zero() && t <= N::one() {
@@ -97,7 +97,7 @@ impl<N: RealField> RayCast<N> for HeightField<N> {
                 let (s, t) = query::closest_points_line_line_parameters(
                     &ray.origin,
                     &ray.dir,
-                    seg.a(),
+                    &seg.a,
                     &seg.scaled_direction(),
                 );
 

--- a/src/query/ray/ray_plane.rs
+++ b/src/query/ray/ray_plane.rs
@@ -51,7 +51,7 @@ impl<N: RealField> RayCast<N> for Plane<N> {
 
         let dpos = -ls_ray.origin;
 
-        let dot_normal_dpos = self.normal().dot(&dpos.coords);
+        let dot_normal_dpos = self.normal.dot(&dpos.coords);
 
         if solid && dot_normal_dpos > na::zero() {
             // The ray is inside of the solid half-space.
@@ -62,13 +62,13 @@ impl<N: RealField> RayCast<N> for Plane<N> {
             ));
         }
 
-        let t = dot_normal_dpos / self.normal().dot(&ls_ray.dir);
+        let t = dot_normal_dpos / self.normal.dot(&ls_ray.dir);
 
         if t >= na::zero() && t <= max_toi {
             let n = if dot_normal_dpos > na::zero() {
-                -*self.normal()
+                -self.normal
             } else {
-                *self.normal()
+                self.normal
             };
 
             Some(RayIntersection::new(t, m * *n, FeatureId::Face(0)))

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -204,7 +204,7 @@ impl<N: RealField> RayCast<N> for Segment<N> {
             let (s, t, parallel) = query::closest_points_line_line_parameters_eps(
                 &ray.origin,
                 &ray.dir,
-                seg.a(),
+                &seg.a,
                 &seg_dir,
                 N::default_epsilon(),
             );
@@ -213,7 +213,7 @@ impl<N: RealField> RayCast<N> for Segment<N> {
                 // The lines are parallel, we have to distinguish
                 // the case where there is no intersection at all
                 // from the case where the line are collinear.
-                let dpos = seg.a() - ray.origin;
+                let dpos = seg.a - ray.origin;
                 let normal = seg.scaled_normal();
 
                 if dpos.dot(&normal).abs() < N::default_epsilon() {

--- a/src/query/ray/ray_triangle.rs
+++ b/src/query/ray/ray_triangle.rs
@@ -14,7 +14,7 @@ impl<N: RealField> RayCast<N> for Triangle<N> {
         _: bool,
     ) -> Option<RayIntersection<N>> {
         let ls_ray = ray.inverse_transform_by(m);
-        let mut inter = ray_intersection_with_triangle(self.a(), self.b(), self.c(), &ls_ray)?.0;
+        let mut inter = ray_intersection_with_triangle(&self.a, &self.b, &self.c, &ls_ray)?.0;
 
         if inter.toi <= max_toi {
             inter.normal = m * inter.normal;

--- a/src/query/time_of_impact/time_of_impact_ball_ball.rs
+++ b/src/query/time_of_impact/time_of_impact_ball_ball.rs
@@ -17,7 +17,7 @@ pub fn time_of_impact_ball_ball<N: RealField>(
     target_distance: N,
 ) -> Option<TOI<N>> {
     let vel = *vel1 - *vel2;
-    let rsum = b1.radius() + b2.radius();
+    let rsum = b1.radius + b2.radius;
     let radius = rsum + target_distance;
     let center = *center1 + (-center2.coords);
     let ray = Ray::new(Point::origin(), -vel);
@@ -41,8 +41,8 @@ pub fn time_of_impact_ball_ball<N: RealField>(
         } else {
             normal1 = Unit::new_unchecked(dpt / radius);
             normal2 = -normal1;
-            witness1 = Point::from(*normal1 * b1.radius());
-            witness2 = Point::from(*normal2 * b2.radius());
+            witness1 = Point::from(*normal1 * b1.radius);
+            witness2 = Point::from(*normal2 * b2.radius);
         }
 
         let status = if inside && center.coords.norm_squared() < rsum * rsum {

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -122,8 +122,8 @@ where
     ) -> BestFirstVisitStatus<N, Self::Result> {
         // Compute the minkowski sum of the two AABBs.
         let msum = AABB::new(
-            *bv.mins() + self.msum_shift + (-self.msum_margin),
-            *bv.maxs() + self.msum_shift + self.msum_margin,
+            bv.mins + self.msum_shift + (-self.msum_margin),
+            bv.maxs + self.msum_shift + self.msum_margin,
         );
 
         // Compute the TOI.

--- a/src/query/time_of_impact/time_of_impact_plane_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_plane_support_map.rs
@@ -21,7 +21,7 @@ where
     G: SupportMap<N>,
 {
     let vel = *vel_other - *vel_plane;
-    let plane_normal = mplane * plane.normal();
+    let plane_normal = mplane * plane.normal;
     // FIXME: add method to get only the local support point.
     // This would avoid the `inverse_transform_point` later.
     let support_point = other.support_point(mother, &-plane_normal);
@@ -42,13 +42,13 @@ where
         } else {
             // Project the witness point to the plane.
             // Note that witness2 is already in the plane's local-space.
-            witness2 = witness2 - **plane.normal() * witness2.coords.dot(plane.normal());
+            witness2 = witness2 - *plane.normal * witness2.coords.dot(&plane.normal);
             status = TOIStatus::Converged
         }
 
         Some(TOI {
             toi,
-            normal1: *plane.normal(),
+            normal1: plane.normal,
             normal2: mother.inverse_transform_unit_vector(&-plane_normal),
             witness1,
             witness2,

--- a/src/shape/ball.rs
+++ b/src/shape/ball.rs
@@ -5,25 +5,22 @@ use crate::shape::SupportMap;
 
 /// A Ball shape.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Ball<N: RealField> {
-    radius: N,
+    /// The radius of the ball.
+    pub radius: N,
 }
 
 impl<N: RealField> Ball<N> {
     /// Creates a new ball from its radius and center.
     #[inline]
     pub fn new(radius: N) -> Ball<N> {
-        assert!(
-            radius > N::zero(),
-            "A ball radius must be strictly positive."
-        );
-
         Ball { radius }
     }
 
     /// The ball radius.
     #[inline]
+    #[deprecated(note = "use the `self.radius` public field directly.")]
     pub fn radius(&self) -> N {
         self.radius
     }
@@ -37,6 +34,6 @@ impl<N: RealField> SupportMap<N> for Ball<N> {
 
     #[inline]
     fn support_point_toward(&self, m: &Isometry<N>, dir: &Unit<Vector<N>>) -> Point<N> {
-        m * Point::origin() + **dir * self.radius()
+        m * Point::origin() + **dir * self.radius
     }
 }

--- a/src/shape/ball.rs
+++ b/src/shape/ball.rs
@@ -34,6 +34,16 @@ impl<N: RealField> SupportMap<N> for Ball<N> {
 
     #[inline]
     fn support_point_toward(&self, m: &Isometry<N>, dir: &Unit<Vector<N>>) -> Point<N> {
-        m * Point::origin() + **dir * self.radius
+        Point::from(m.translation.vector) + **dir * self.radius
+    }
+
+    #[inline]
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        self.local_support_point_toward(&Unit::new_normalize(*dir))
+    }
+
+    #[inline]
+    fn local_support_point_toward(&self, dir: &Unit<Vector<N>>) -> Point<N> {
+        Point::from(**dir * self.radius)
     }
 }

--- a/src/shape/capsule.rs
+++ b/src/shape/capsule.rs
@@ -8,10 +8,12 @@ use crate::shape::{FeatureId, Segment, SupportMap};
 
 /// SupportMap description of a capsule shape with its principal axis aligned with the `y` axis.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Capsule<N> {
-    half_height: N,
-    radius: N,
+    /// The half-height of the capsule's cylindrical part.
+    pub half_height: N,
+    /// The radius of the capsule.
+    pub radius: N,
 }
 
 impl<N: RealField> Capsule<N> {
@@ -21,8 +23,6 @@ impl<N: RealField> Capsule<N> {
     /// * `half_height` - the half length of the capsule along the `y` axis.
     /// * `radius` - radius of the rounded part of the capsule.
     pub fn new(half_height: N, radius: N) -> Capsule<N> {
-        assert!(half_height.is_positive() && radius.is_positive());
-
         Capsule {
             half_height,
             radius,
@@ -31,6 +31,7 @@ impl<N: RealField> Capsule<N> {
 
     /// The capsule half length along its local `y` axis.
     #[inline]
+    #[deprecated(note = "use the `self.half_height` public field directly.")]
     pub fn half_height(&self) -> N {
         self.half_height
     }
@@ -43,6 +44,7 @@ impl<N: RealField> Capsule<N> {
 
     /// The radius of the capsule's rounded part.
     #[inline]
+    #[deprecated(note = "use the `self.radius` public field directly.")]
     pub fn radius(&self) -> N {
         self.radius
     }
@@ -80,12 +82,12 @@ impl<N: RealField> SupportMap<N> for Capsule<N> {
         let mut res: Vector<N> = na::zero();
 
         if local_dir[1].is_negative() {
-            res[1] = -self.half_height()
+            res[1] = -self.half_height
         } else {
-            res[1] = self.half_height()
+            res[1] = self.half_height
         }
 
-        m * Point::from(res + local_dir * self.radius())
+        m * Point::from(res + local_dir * self.radius)
     }
 }
 

--- a/src/shape/capsule.rs
+++ b/src/shape/capsule.rs
@@ -2,7 +2,7 @@
 
 use na::{self, RealField, Unit};
 
-use crate::math::{Isometry, Point, Vector};
+use crate::math::{Point, Vector};
 use crate::query::{Contact, ContactKinematic, ContactPreprocessor};
 use crate::shape::{FeatureId, Segment, SupportMap};
 
@@ -71,23 +71,15 @@ impl<N: RealField> Capsule<N> {
 
 impl<N: RealField> SupportMap<N> for Capsule<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        self.support_point_toward(m, &Unit::new_normalize(*dir))
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        self.local_support_point_toward(&Unit::new_normalize(*dir))
     }
 
     #[inline]
-    fn support_point_toward(&self, m: &Isometry<N>, dir: &Unit<Vector<N>>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-
+    fn local_support_point_toward(&self, dir: &Unit<Vector<N>>) -> Point<N> {
         let mut res: Vector<N> = na::zero();
-
-        if local_dir[1].is_negative() {
-            res[1] = -self.half_height
-        } else {
-            res[1] = self.half_height
-        }
-
-        m * Point::from(res + local_dir * self.radius)
+        res[1] = dir[1].copysign(self.half_height);
+        Point::from(res + **dir * self.radius)
     }
 }
 

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -6,10 +6,12 @@ use na::{self, RealField};
 
 /// SupportMap description of a cylinder shape with its principal axis aligned with the `y` axis.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Cone<N> {
-    half_height: N,
-    radius: N,
+    /// The half-height of the cone.
+    pub half_height: N,
+    /// The base radius of the cone.
+    pub radius: N,
 }
 
 impl<N: RealField> Cone<N> {
@@ -19,22 +21,22 @@ impl<N: RealField> Cone<N> {
     /// * `half_height` - the half length of the cone along the `y` axis.
     /// * `radius` - the length of the cone along all other axis.
     pub fn new(half_height: N, radius: N) -> Cone<N> {
-        assert!(half_height.is_positive() && radius.is_positive());
-
         Cone {
-            half_height: half_height,
-            radius: radius,
+            half_height,
+            radius,
         }
     }
 
     /// The cone half length along the `y` axis.
     #[inline]
+    #[deprecated(note = "use the `self.half_height` public field directly.")]
     pub fn half_height(&self) -> N {
         self.half_height
     }
 
     /// The radius of the cone along all but the `y` axis.
     #[inline]
+    #[deprecated(note = "use the `self.radius` public field directly.")]
     pub fn radius(&self) -> N {
         self.radius
     }
@@ -53,17 +55,17 @@ impl<N: RealField> SupportMap<N> for Cone<N> {
             vres = na::zero();
 
             if local_dir[1].is_negative() {
-                vres[1] = -self.half_height()
+                vres[1] = -self.half_height
             } else {
-                vres[1] = self.half_height()
+                vres[1] = self.half_height
             }
         } else {
-            vres = vres * self.radius();
-            vres[1] = -self.half_height();
+            vres = vres * self.radius;
+            vres[1] = -self.half_height;
 
-            if local_dir.dot(&vres) < local_dir[1] * self.half_height() {
+            if local_dir.dot(&vres) < local_dir[1] * self.half_height {
                 vres = na::zero();
-                vres[1] = self.half_height()
+                vres[1] = self.half_height
             }
         }
 

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -1,6 +1,6 @@
 //! Support mapping based Cone shape.
 
-use crate::math::{Isometry, Point, Vector};
+use crate::math::{Point, Vector};
 use crate::shape::SupportMap;
 use na::{self, RealField};
 
@@ -44,31 +44,24 @@ impl<N: RealField> Cone<N> {
 
 impl<N: RealField> SupportMap<N> for Cone<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-
-        let mut vres = local_dir;
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        let mut vres = *dir;
 
         vres[1] = na::zero();
 
         if vres.normalize_mut().is_zero() {
             vres = na::zero();
-
-            if local_dir[1].is_negative() {
-                vres[1] = -self.half_height
-            } else {
-                vres[1] = self.half_height
-            }
+            vres[1] = dir[1].copysign(self.half_height);
         } else {
             vres = vres * self.radius;
             vres[1] = -self.half_height;
 
-            if local_dir.dot(&vres) < local_dir[1] * self.half_height {
+            if dir.dot(&vres) < dir[1] * self.half_height {
                 vres = na::zero();
                 vres[1] = self.half_height
             }
         }
 
-        m * Point::from(vres)
+        Point::from(vres)
     }
 }

--- a/src/shape/convex.rs
+++ b/src/shape/convex.rs
@@ -415,11 +415,8 @@ impl<N: RealField> ConvexHull<N> {
 
 impl<N: RealField> SupportMap<N> for ConvexHull<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-        let best_pt = utils::point_cloud_support_point(&local_dir, self.points());
-
-        m * best_pt
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        utils::point_cloud_support_point(dir, self.points())
     }
 }
 

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -110,11 +110,8 @@ impl<N: RealField> ConvexPolygon<N> {
 
 impl<N: RealField> SupportMap<N> for ConvexPolygon<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-        let best_pt = utils::point_cloud_support_point(&local_dir, self.points());
-
-        m * best_pt
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        utils::point_cloud_support_point(dir, self.points())
     }
 }
 

--- a/src/shape/convex_polygonal_feature2.rs
+++ b/src/shape/convex_polygonal_feature2.rs
@@ -125,15 +125,9 @@ impl<N: RealField> ConvexPolygonalFeature<N> {
         let mut seg1 = Segment::new(self.vertices[0], self.vertices[1]);
         let mut seg2 = Segment::new(other.vertices[0], other.vertices[1]);
 
-        let ref_pt = *seg1.a();
-        let mut range1 = [
-            (*seg1.a() - ref_pt).dot(&ortho),
-            (*seg1.b() - ref_pt).dot(&ortho),
-        ];
-        let mut range2 = [
-            (*seg2.a() - ref_pt).dot(&ortho),
-            (*seg2.b() - ref_pt).dot(&ortho),
-        ];
+        let ref_pt = seg1.a;
+        let mut range1 = [(seg1.a - ref_pt).dot(&ortho), (seg1.b - ref_pt).dot(&ortho)];
+        let mut range2 = [(seg2.a - ref_pt).dot(&ortho), (seg2.b - ref_pt).dot(&ortho)];
         let mut features1 = [self.vertices_id[0], self.vertices_id[1]];
         let mut features2 = [other.vertices_id[0], other.vertices_id[1]];
 
@@ -160,7 +154,7 @@ impl<N: RealField> ConvexPolygonalFeature<N> {
         if range2[0] > range1[0] {
             let bcoord = (range2[0] - range1[0]) / length1;
             let p1 = seg1.point_at(&SegmentPointLocation::OnEdge([_1 - bcoord, bcoord]));
-            let p2 = *seg2.a();
+            let p2 = seg2.a;
             let contact = Contact::new_wo_depth(p1, p2, *normal);
 
             if -contact.depth <= prediction.linear() {
@@ -168,7 +162,7 @@ impl<N: RealField> ConvexPolygonalFeature<N> {
             }
         } else {
             let bcoord = (range1[0] - range2[0]) / length2;
-            let p1 = *seg1.a();
+            let p1 = seg1.a;
             let p2 = seg2.point_at(&SegmentPointLocation::OnEdge([_1 - bcoord, bcoord]));
             let contact = Contact::new_wo_depth(p1, p2, *normal);
 
@@ -180,7 +174,7 @@ impl<N: RealField> ConvexPolygonalFeature<N> {
         if range2[1] < range1[1] {
             let bcoord = (range2[1] - range1[0]) / length1;
             let p1 = seg1.point_at(&SegmentPointLocation::OnEdge([_1 - bcoord, bcoord]));
-            let p2 = *seg2.b();
+            let p2 = seg2.b;
             let contact = Contact::new_wo_depth(p1, p2, *normal);
 
             if -contact.depth <= prediction.linear() {
@@ -188,7 +182,7 @@ impl<N: RealField> ConvexPolygonalFeature<N> {
             }
         } else {
             let bcoord = (range1[1] - range2[0]) / length2;
-            let p1 = *seg1.b();
+            let p1 = seg1.b;
             let p2 = seg2.point_at(&SegmentPointLocation::OnEdge([_1 - bcoord, bcoord]));
             let contact = Contact::new_wo_depth(p1, p2, *normal);
 

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -134,18 +134,14 @@ impl<N: RealField> Cuboid<N> {
 
 impl<N: RealField> SupportMap<N> for Cuboid<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
         let mut res = self.half_extents;
 
         for i in 0usize..DIM {
-            if local_dir[i] < N::zero() {
-                res[i] = -res[i];
-            }
+            res[i] = dir[i].copysign(res[i]);
         }
 
-        m * Point::from(res)
+        res.into()
     }
 }
 

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -7,9 +7,10 @@ use std::f64;
 
 /// Shape of a box.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Cuboid<N: RealField> {
-    half_extents: Vector<N>,
+    /// The half-extents of the cuboid.
+    pub half_extents: Vector<N>,
 }
 
 // NOTE: format of the cuboid feature id:
@@ -24,19 +25,14 @@ impl<N: RealField> Cuboid<N> {
     /// axis. Each half-extent must be positive.
     #[inline]
     pub fn new(half_extents: Vector<N>) -> Cuboid<N> {
-        for i in 0..DIM {
-            assert!(half_extents[i] >= N::zero());
-        }
-
-        Cuboid {
-            half_extents: half_extents,
-        }
+        Cuboid { half_extents }
     }
 }
 
 impl<N: RealField> Cuboid<N> {
     /// The half-extents of this box. Half-extents are the box half-width along each axis.
     #[inline]
+    #[deprecated(note = "use the `self.half_extents` public field directly.")]
     pub fn half_extents(&self) -> &Vector<N> {
         &self.half_extents
     }
@@ -141,7 +137,7 @@ impl<N: RealField> SupportMap<N> for Cuboid<N> {
     fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
         let local_dir = m.inverse_transform_vector(dir);
 
-        let mut res = *self.half_extents();
+        let mut res = self.half_extents;
 
         for i in 0usize..DIM {
             if local_dir[i] < N::zero() {

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -1,6 +1,6 @@
 //! Support mapping based Cylinder shape.
 
-use crate::math::{Isometry, Point, Vector};
+use crate::math::{Point, Vector};
 use crate::shape::SupportMap;
 use na::{self, RealField};
 
@@ -45,11 +45,8 @@ impl<N: RealField> Cylinder<N> {
 }
 
 impl<N: RealField> SupportMap<N> for Cylinder<N> {
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-
-        let mut vres = local_dir;
-        let negative = local_dir[1].is_negative();
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        let mut vres = *dir;
 
         vres[1] = na::zero();
 
@@ -59,12 +56,8 @@ impl<N: RealField> SupportMap<N> for Cylinder<N> {
             vres = vres * self.radius;
         }
 
-        if negative {
-            vres[1] = -self.half_height
-        } else {
-            vres[1] = self.half_height
-        }
+        vres[1] = dir[1].copysign(self.half_height);
 
-        m * Point::from(vres)
+        Point::from(vres)
     }
 }

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -6,10 +6,12 @@ use na::{self, RealField};
 
 /// SupportMap description of a cylinder shape with its principal axis aligned with the `y` axis.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Cylinder<N> {
-    half_height: N,
-    radius: N,
+    /// The half-height of the cylinder.
+    pub half_height: N,
+    /// The radius fo the cylinder.
+    pub radius: N,
 }
 
 impl<N: RealField> Cylinder<N> {
@@ -22,19 +24,21 @@ impl<N: RealField> Cylinder<N> {
         assert!(half_height.is_positive() && radius.is_positive());
 
         Cylinder {
-            half_height: half_height,
-            radius: radius,
+            half_height,
+            radius,
         }
     }
 
     /// The cylinder half length along the `y` axis.
     #[inline]
+    #[deprecated(note = "use the `self.half_height` field directly.")]
     pub fn half_height(&self) -> N {
         self.half_height
     }
 
     /// The radius of the cylinder along all but the `y` axis.
     #[inline]
+    #[deprecated(note = "use the `self.radius` field directly.")]
     pub fn radius(&self) -> N {
         self.radius
     }
@@ -52,13 +56,13 @@ impl<N: RealField> SupportMap<N> for Cylinder<N> {
         if vres.normalize_mut().is_zero() {
             vres = na::zero()
         } else {
-            vres = vres * self.radius();
+            vres = vres * self.radius;
         }
 
         if negative {
-            vres[1] = -self.half_height()
+            vres[1] = -self.half_height
         } else {
-            vres[1] = self.half_height()
+            vres[1] = self.half_height
         }
 
         m * Point::from(vres)

--- a/src/shape/heightfield2.rs
+++ b/src/shape/heightfield2.rs
@@ -162,8 +162,8 @@ impl<N: RealField> HeightField<N> {
         f: &mut impl FnMut(usize, &Segment<N>, &dyn ContactPreprocessor<N>),
     ) {
         let _0_5: N = na::convert(0.5);
-        let ref_mins = aabb.mins().coords.component_div(&self.scale);
-        let ref_maxs = aabb.maxs().coords.component_div(&self.scale);
+        let ref_mins = aabb.mins.coords.component_div(&self.scale);
+        let ref_maxs = aabb.maxs.coords.component_div(&self.scale);
         let seg_length = N::one() / na::convert(self.heights.len() as f64 - 1.0);
 
         if ref_maxs.x < -_0_5 || ref_mins.x > _0_5 {

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -370,8 +370,8 @@ impl<N: RealField> HeightField<N> {
         let ncells_x = self.ncols();
         let ncells_z = self.nrows();
 
-        let ref_mins = aabb.mins().coords.component_div(&self.scale);
-        let ref_maxs = aabb.maxs().coords.component_div(&self.scale);
+        let ref_mins = aabb.mins.coords.component_div(&self.scale);
+        let ref_maxs = aabb.maxs.coords.component_div(&self.scale);
         let cell_width = self.unit_cell_width();
         let cell_height = self.unit_cell_height();
 

--- a/src/shape/plane.rs
+++ b/src/shape/plane.rs
@@ -7,18 +7,19 @@ use na::{RealField, Unit};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Plane<N: RealField> {
     /// The plane normal.
-    normal: Unit<Vector<N>>,
+    pub normal: Unit<Vector<N>>,
 }
 
 impl<N: RealField> Plane<N> {
     /// Builds a new plane from its center and its normal.
     #[inline]
     pub fn new(normal: Unit<Vector<N>>) -> Plane<N> {
-        Plane { normal: normal }
+        Plane { normal }
     }
 
     /// The plane normal.
     #[inline]
+    #[deprecated(note = "use the `self.normal` public field directly.")]
     pub fn normal(&self) -> &Unit<Vector<N>> {
         &self.normal
     }

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -655,7 +655,7 @@ impl<N: RealField> DeformableShape<N> for Polyline<N> {
                     Point::from_slice(&coords[pid1..pid1 + DIM]),
                     Point::from_slice(&coords[pid2..pid2 + DIM]),
                 );
-                approx.point = *seg.a();
+                approx.point = seg.a;
 
                 if let Some(dir) = seg.direction() {
                     approx.geometry = NeighborhoodGeometry::Line(dir);
@@ -680,7 +680,7 @@ impl<N: RealField> DeformableShape<N> for Polyline<N> {
                     Point::from_slice(&coords[pid2..pid2 + DIM]),
                 );
 
-                approx.point = *seg.a();
+                approx.point = seg.a;
 
                 if let Some(n) = seg.normal() {
                     if !is_backface {

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -181,13 +181,11 @@ impl<N: RealField> Segment<N> {
 
 impl<N: RealField> SupportMap<N> for Segment<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
-
-        if self.a.coords.dot(&local_dir) > self.b.coords.dot(&local_dir) {
-            m * self.a
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        if self.a.coords.dot(dir) > self.b.coords.dot(dir) {
+            self.a
         } else {
-            m * self.b
+            self.b
         }
     }
 }

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -114,8 +114,9 @@ impl<N: RealField> Segment<N> {
         Unit::try_new(self.scaled_normal(), N::default_epsilon())
     }
 
+    /// Returns `None`. Exists only for API similarity with the 2D ncollide.
     #[cfg(feature = "dim3")]
-    pub(crate) fn normal(&self) -> Option<Unit<Vector<N>>> {
+    pub fn normal(&self) -> Option<Unit<Vector<N>>> {
         None
     }
 

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -12,10 +12,12 @@ use std::mem;
 /// A segment shape.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Segment<N: RealField> {
-    a: Point<N>,
-    b: Point<N>,
+    /// The segment first point.
+    pub a: Point<N>,
+    /// The segment second point.
+    pub b: Point<N>,
 }
 
 /// Logical description of the location of a point on a triangle.
@@ -60,12 +62,14 @@ impl<N: RealField> Segment<N> {
 impl<N: RealField> Segment<N> {
     /// The first point of this segment.
     #[inline]
+    #[deprecated(note = "use the `self.a` public field directly.")]
     pub fn a(&self) -> &Point<N> {
         &self.a
     }
 
     /// The second point of this segment.
     #[inline]
+    #[deprecated(note = "use the `self.b` public field directly.")]
     pub fn b(&self) -> &Point<N> {
         &self.b
     }
@@ -74,7 +78,7 @@ impl<N: RealField> Segment<N> {
 impl<N: RealField> Segment<N> {
     /// The direction of this segment scaled by its length.
     ///
-    /// Points from `self.a()` toward `self.b()`.
+    /// Points from `self.a` toward `self.b`.
     pub fn scaled_direction(&self) -> Vector<N> {
         self.b - self.a
     }

--- a/src/shape/shape_impl.rs
+++ b/src/shape/shape_impl.rs
@@ -279,7 +279,7 @@ impl<N: RealField> Shape<N> for Plane<N> {
         _: Option<&[N]>,
         dir: &Unit<Vector<N>>,
     ) -> bool {
-        let world_normal = m * self.normal();
+        let world_normal = m * self.normal;
         dir.dot(&world_normal) <= N::zero()
     }
 }

--- a/src/shape/support_map.rs
+++ b/src/shape/support_map.rs
@@ -8,16 +8,29 @@ use na::{RealField, Unit};
 /// # Parameters:
 ///   * V - type of the support mapping direction argument and of the returned point.
 pub trait SupportMap<N: RealField> {
-    /**
-     * Evaluates the support function of the object.
-     *
-     * A support function is a function associating a vector to the shape point which maximizes
-     * their dot product.
-     */
-    fn support_point(&self, transform: &Isometry<N>, dir: &Vector<N>) -> Point<N>;
+    // Evaluates the support function of this shape.
+    //
+    // A support function is a function associating a vector to the shape point which maximizes
+    // their dot product.
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N>;
+
+    /// Same as `self.local_support_point` except that `dir` is normalized.
+    fn local_support_point_toward(&self, dir: &Unit<Vector<N>>) -> Point<N> {
+        self.local_support_point(dir.as_ref())
+    }
+
+    // Evaluates the support function of this shape transformed by `transform`.
+    //
+    // A support function is a function associating a vector to the shape point which maximizes
+    // their dot product.
+    fn support_point(&self, transform: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
+        let local_dir = transform.inverse_transform_vector(dir);
+        transform * self.local_support_point(&local_dir)
+    }
 
     /// Same as `self.support_point` except that `dir` is normalized.
     fn support_point_toward(&self, transform: &Isometry<N>, dir: &Unit<Vector<N>>) -> Point<N> {
-        self.support_point(transform, dir.as_ref())
+        let local_dir = Unit::new_unchecked(transform.inverse_transform_vector(dir));
+        transform * self.local_support_point_toward(&local_dir)
     }
 }

--- a/src/shape/tetrahedron.rs
+++ b/src/shape/tetrahedron.rs
@@ -10,10 +10,14 @@ use std::mem;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct Tetrahedron<N: RealField> {
-    a: Point<N>,
-    b: Point<N>,
-    c: Point<N>,
-    d: Point<N>,
+    /// The tetrahedron first point.
+    pub a: Point<N>,
+    /// The tetrahedron first point.
+    pub b: Point<N>,
+    /// The tetrahedron first point.
+    pub c: Point<N>,
+    /// The tetrahedron first point.
+    pub d: Point<N>,
 }
 
 /// Logical description of the location of a point on a triangle.
@@ -101,24 +105,28 @@ impl<N: RealField> Tetrahedron<N> {
 
     /// The fist point of this tetrahedron.
     #[inline]
+    #[deprecated(note = "use the `self.a` public field directly.")]
     pub fn a(&self) -> &Point<N> {
         &self.a
     }
 
     /// The second point of this tetrahedron.
     #[inline]
+    #[deprecated(note = "use the `self.b` public field directly.")]
     pub fn b(&self) -> &Point<N> {
         &self.b
     }
 
     /// The third point of this tetrahedron.
     #[inline]
+    #[deprecated(note = "use the `self.c` public field directly.")]
     pub fn c(&self) -> &Point<N> {
         &self.c
     }
 
     /// The fourth point of this tetrahedron.
     #[inline]
+    #[deprecated(note = "use the `self.d` public field directly.")]
     pub fn d(&self) -> &Point<N> {
         &self.d
     }

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -289,14 +289,12 @@ impl<N: RealField> Triangle<N> {
 
 impl<N: RealField> SupportMap<N> for Triangle<N> {
     #[inline]
-    fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
-        let local_dir = m.inverse_transform_vector(dir);
+    fn local_support_point(&self, dir: &Vector<N>) -> Point<N> {
+        let d1 = self.a.coords.dot(dir);
+        let d2 = self.b.coords.dot(dir);
+        let d3 = self.c.coords.dot(dir);
 
-        let d1 = self.a.coords.dot(&local_dir);
-        let d2 = self.b.coords.dot(&local_dir);
-        let d3 = self.c.coords.dot(&local_dir);
-
-        let res = if d1 > d2 {
+        if d1 > d2 {
             if d1 > d3 {
                 self.a
             } else {
@@ -308,9 +306,7 @@ impl<N: RealField> SupportMap<N> for Triangle<N> {
             } else {
                 self.c
             }
-        };
-
-        m * res
+        }
     }
 }
 

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -14,11 +14,14 @@ use std::mem;
 /// A triangle shape.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Triangle<N: RealField> {
-    a: Point<N>,
-    b: Point<N>,
-    c: Point<N>,
+    /// The triangle first point.
+    pub a: Point<N>,
+    /// The triangle second point.
+    pub b: Point<N>,
+    /// The triangle third point.
+    pub c: Point<N>,
 }
 
 /// Description of the location of a point on a triangle.
@@ -101,18 +104,21 @@ impl<N: RealField> Triangle<N> {
 
     /// The fist point of this triangle.
     #[inline]
+    #[deprecated(note = "use the `self.a` public field directly.")]
     pub fn a(&self) -> &Point<N> {
         &self.a
     }
 
     /// The second point of this triangle.
     #[inline]
+    #[deprecated(note = "use the `self.b` public field directly.")]
     pub fn b(&self) -> &Point<N> {
         &self.b
     }
 
     /// The third point of this triangle.
     #[inline]
+    #[deprecated(note = "use the `self.c` public field directly.")]
     pub fn c(&self) -> &Point<N> {
         &self.c
     }
@@ -286,21 +292,21 @@ impl<N: RealField> SupportMap<N> for Triangle<N> {
     fn support_point(&self, m: &Isometry<N>, dir: &Vector<N>) -> Point<N> {
         let local_dir = m.inverse_transform_vector(dir);
 
-        let d1 = self.a().coords.dot(&local_dir);
-        let d2 = self.b().coords.dot(&local_dir);
-        let d3 = self.c().coords.dot(&local_dir);
+        let d1 = self.a.coords.dot(&local_dir);
+        let d2 = self.b.coords.dot(&local_dir);
+        let d3 = self.c.coords.dot(&local_dir);
 
         let res = if d1 > d2 {
             if d1 > d3 {
-                self.a()
+                self.a
             } else {
-                self.c()
+                self.c
             }
         } else {
             if d2 > d3 {
-                self.b()
+                self.b
             } else {
-                self.c()
+                self.c
             }
         };
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -123,9 +123,9 @@ impl<N: RealField> TriMesh<N> {
                 let normal = triangle.normal();
                 let side_normals = normal.map(|n| {
                     [
-                        Unit::new_normalize((triangle.b() - triangle.a()).cross(&n)),
-                        Unit::new_normalize((triangle.c() - triangle.b()).cross(&n)),
-                        Unit::new_normalize((triangle.a() - triangle.c()).cross(&n)),
+                        Unit::new_normalize((triangle.b - triangle.a).cross(&n)),
+                        Unit::new_normalize((triangle.c - triangle.b).cross(&n)),
+                        Unit::new_normalize((triangle.a - triangle.c).cross(&n)),
                     ]
                 });
 
@@ -848,7 +848,7 @@ impl<N: RealField> DeformableShape<N> for TriMesh<N> {
                     Point::from_slice(&coords[pid1..pid1 + DIM]),
                     Point::from_slice(&coords[pid2..pid2 + DIM]),
                 );
-                approx.point = *seg.a();
+                approx.point = seg.a;
 
                 if let Some(dir) = seg.direction() {
                     approx.geometry = NeighborhoodGeometry::Line(dir);
@@ -872,7 +872,7 @@ impl<N: RealField> DeformableShape<N> for TriMesh<N> {
                     Point::from_slice(&coords[pid3..pid3 + DIM]),
                 );
 
-                approx.point = *tri.a();
+                approx.point = tri.a;
 
                 if let Some(n) = tri.normal() {
                     if !is_backface {

--- a/src/transformation/convex_hull_utils.rs
+++ b/src/transformation/convex_hull_utils.rs
@@ -57,7 +57,7 @@ where
 /// Scale and center the given set of point depending on their AABB.
 pub fn normalize<N: RealField>(coords: &mut [Point<N>]) -> (Point<N>, N) {
     let aabb = bounding_volume::point_cloud_aabb(&Isometry::identity(), &coords[..]);
-    let diag = na::distance(aabb.mins(), aabb.maxs());
+    let diag = na::distance(&aabb.mins, &aabb.maxs);
     let center = aabb.center();
 
     for c in coords.iter_mut() {

--- a/src/transformation/convex_hull_utils.rs
+++ b/src/transformation/convex_hull_utils.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume;
-use crate::math::{Isometry, Point};
+use crate::math::Point;
 use crate::num::Bounded;
 use na::allocator::Allocator;
 use na::base::{DefaultAllocator, DimName};
@@ -56,7 +56,7 @@ where
 
 /// Scale and center the given set of point depending on their AABB.
 pub fn normalize<N: RealField>(coords: &mut [Point<N>]) -> (Point<N>, N) {
-    let aabb = bounding_volume::point_cloud_aabb(&Isometry::identity(), &coords[..]);
+    let aabb = bounding_volume::local_point_cloud_aabb(&coords[..]);
     let diag = na::distance(&aabb.mins, &aabb.maxs);
     let center = aabb.center();
 

--- a/src/transformation/hacd.rs
+++ b/src/transformation/hacd.rs
@@ -160,7 +160,7 @@ pub fn hacd<N: RealField>(
 }
 
 fn normalize<N: RealField>(mesh: &mut TriMesh<N>) -> (Point3<N>, N) {
-    let aabb = bounding_volume::point_cloud_aabb(&Isometry::identity(), &mesh.coords[..]);
+    let aabb = bounding_volume::local_point_cloud_aabb(&mesh.coords[..]);
     let diag = na::distance(&aabb.mins, &aabb.maxs);
     let center = aabb.center();
 
@@ -474,7 +474,7 @@ impl<N: RealField> DualGraphEdge<N> {
             concavity: &mut N,
             ancestors: &mut BinaryHeap<VertexWithConcavity<N>>,
         ) {
-            let sv = chull.support_point(&Isometry::identity(), &ray.dir);
+            let sv = chull.local_support_point(&ray.dir);
             let distance = sv.coords.dot(&ray.dir);
 
             if !relative_eq!(distance, na::zero()) {
@@ -783,6 +783,11 @@ impl<'a, N: RealField> ConvexPair<'a, N> {
 impl<'a, N: RealField> SupportMap<N> for ConvexPair<'a, N> {
     #[inline]
     fn support_point(&self, _: &Isometry<N>, dir: &Vector3<N>) -> Point3<N> {
+        self.local_support_point(dir)
+    }
+
+    #[inline]
+    fn local_support_point(&self, dir: &Vector3<N>) -> Point3<N> {
         let sa = utils::point_cloud_support_point(dir, self.a);
         let sb = utils::point_cloud_support_point(dir, self.b);
 

--- a/src/transformation/hacd.rs
+++ b/src/transformation/hacd.rs
@@ -161,7 +161,7 @@ pub fn hacd<N: RealField>(
 
 fn normalize<N: RealField>(mesh: &mut TriMesh<N>) -> (Point3<N>, N) {
     let aabb = bounding_volume::point_cloud_aabb(&Isometry::identity(), &mesh.coords[..]);
-    let diag = na::distance(aabb.mins(), aabb.maxs());
+    let diag = na::distance(&aabb.mins, &aabb.maxs);
     let center = aabb.center();
 
     mesh.translate_by(&Translation3::from(-center.coords));
@@ -410,7 +410,7 @@ impl<N: RealField> DualGraphEdge<N> {
 
         // FIXME: refactor this.
         let aabb = dual_graph[v1].aabb.merged(&dual_graph[v2].aabb);
-        let diagonal = na::distance(aabb.mins(), aabb.maxs());
+        let diagonal = na::distance(&aabb.mins, &aabb.maxs);
         let shape_cost;
 
         if area.is_zero() || diagonal.is_zero() {

--- a/src/transformation/to_polyline/ball_to_polyline.rs
+++ b/src/transformation/to_polyline/ball_to_polyline.rs
@@ -8,7 +8,7 @@ impl<N: RealField> ToPolyline<N> for Ball<N> {
     type DiscretizationParameter = u32;
 
     fn to_polyline(&self, nsubdiv: u32) -> Polyline<N> {
-        let diameter = self.radius() * na::convert(2.0f64);
+        let diameter = self.radius * na::convert(2.0f64);
 
         procedural::circle(&diameter, nsubdiv)
     }

--- a/src/transformation/to_polyline/capsule_to_polyline.rs
+++ b/src/transformation/to_polyline/capsule_to_polyline.rs
@@ -15,12 +15,12 @@ impl<N: RealField> ToPolyline<N> for Capsule<N> {
 
         let mut points: Vec<Point2<N>> = Vec::with_capacity(nsubdiv as usize);
 
-        utils::push_xy_arc(self.radius(), nsubdiv, dtheta, &mut points);
+        utils::push_xy_arc(self.radius, nsubdiv, dtheta, &mut points);
 
         let npoints = points.len();
 
         for i in 0..npoints {
-            let new_point = points[i] + Vector2::new(na::zero(), self.half_height());
+            let new_point = points[i] + Vector2::new(na::zero(), self.half_height);
 
             points.push(-new_point);
             points[i] = new_point;

--- a/src/transformation/to_polyline/cuboid_to_polyline.rs
+++ b/src/transformation/to_polyline/cuboid_to_polyline.rs
@@ -11,6 +11,6 @@ impl<N: RealField> ToPolyline<N> for Cuboid<N> {
     fn to_polyline(&self, _: ()) -> Polyline<N> {
         let _2: N = na::convert(2.0f64);
 
-        procedural::rectangle(&(*self.half_extents() * _2))
+        procedural::rectangle(&(self.half_extents * _2))
     }
 }

--- a/src/transformation/to_polyline/segment_to_polyline.rs
+++ b/src/transformation/to_polyline/segment_to_polyline.rs
@@ -7,6 +7,6 @@ impl<N: RealField> ToPolyline<N> for Segment<N> {
     type DiscretizationParameter = ();
 
     fn to_polyline(&self, _: ()) -> Polyline<N> {
-        Polyline::new(vec![*self.a(), *self.b()], None)
+        Polyline::new(vec![self.a, self.b], None)
     }
 }

--- a/src/transformation/to_polyline/triangle_to_polyline.rs
+++ b/src/transformation/to_polyline/triangle_to_polyline.rs
@@ -7,6 +7,6 @@ impl<N: RealField> ToPolyline<N> for Triangle<N> {
     type DiscretizationParameter = ();
 
     fn to_polyline(&self, _: ()) -> Polyline<N> {
-        Polyline::new(vec![*self.a(), *self.b(), *self.c()], None)
+        Polyline::new(vec![self.a, self.b, self.c], None)
     }
 }

--- a/src/transformation/to_trimesh/ball_to_trimesh.rs
+++ b/src/transformation/to_trimesh/ball_to_trimesh.rs
@@ -10,7 +10,7 @@ impl<N: RealField> ToTriMesh<N> for Ball<N> {
 
     fn to_trimesh(&self, (ntheta_subdiv, nphi_subdiv): (u32, u32)) -> TriMesh<N> {
         procedural::sphere(
-            self.radius() * na::convert(2.0f64),
+            self.radius * na::convert(2.0f64),
             ntheta_subdiv,
             nphi_subdiv,
             true,

--- a/src/transformation/to_trimesh/capsule_to_trimesh.rs
+++ b/src/transformation/to_trimesh/capsule_to_trimesh.rs
@@ -9,8 +9,8 @@ impl<N: RealField> ToTriMesh<N> for Capsule<N> {
     type DiscretizationParameter = (u32, u32);
 
     fn to_trimesh(&self, (ntheta_subdiv, nphi_subdiv): (u32, u32)) -> TriMesh<N> {
-        let diameter = self.radius() * na::convert(2.0f64);
-        let height = self.half_height() * na::convert(2.0f64);
+        let diameter = self.radius * na::convert(2.0f64);
+        let height = self.half_height * na::convert(2.0f64);
         // FIXME: the fact `capsule` does not take directly the half_height and the radius feels
         // inconsistant.
         procedural::capsule(&diameter, &height, ntheta_subdiv, nphi_subdiv)

--- a/src/transformation/to_trimesh/cone_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cone_to_trimesh.rs
@@ -11,8 +11,8 @@ impl<N: RealField> ToTriMesh<N> for Cone<N> {
     fn to_trimesh(&self, nsubdiv: u32) -> TriMesh<N> {
         // FIXME, inconsistancy we should be able to work directly with the radius.
         // FIXME, inconsistancy we should be able to work directly with the half height.
-        let diameter = self.radius() * na::convert(2.0f64);
-        let height = self.half_height() * na::convert(2.0f64);
+        let diameter = self.radius * na::convert(2.0f64);
+        let height = self.half_height * na::convert(2.0f64);
 
         procedural::cone(diameter, height, nsubdiv)
     }

--- a/src/transformation/to_trimesh/cuboid_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cuboid_to_trimesh.rs
@@ -11,7 +11,7 @@ impl<N: RealField> ToTriMesh<N> for Cuboid<N> {
     fn to_trimesh(&self, _: ()) -> TriMesh<N> {
         let _2: N = na::convert(2.0f64);
 
-        procedural::cuboid(&(*self.half_extents() * _2))
+        procedural::cuboid(&(self.half_extents * _2))
     }
 }
 

--- a/src/transformation/to_trimesh/cylinder_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cylinder_to_trimesh.rs
@@ -9,8 +9,8 @@ impl<N: RealField> ToTriMesh<N> for Cylinder<N> {
     type DiscretizationParameter = u32;
 
     fn to_trimesh(&self, nsubdiv: u32) -> TriMesh<N> {
-        let diameter = self.radius() * na::convert(2.0f64);
-        let height = self.half_height() * na::convert(2.0f64);
+        let diameter = self.radius * na::convert(2.0f64);
+        let height = self.half_height * na::convert(2.0f64);
 
         procedural::cylinder(diameter, height, nsubdiv)
     }

--- a/src/transformation/to_trimesh/heightfield_to_trimesh.rs
+++ b/src/transformation/to_trimesh/heightfield_to_trimesh.rs
@@ -10,9 +10,9 @@ impl<N: RealField> ToTriMesh<N> for shape::HeightField<N> {
         let mut vertices = Vec::new();
 
         for tri in self.triangles() {
-            vertices.push(*tri.a());
-            vertices.push(*tri.b());
-            vertices.push(*tri.c());
+            vertices.push(tri.a);
+            vertices.push(tri.b);
+            vertices.push(tri.c);
         }
 
         TriMesh::new(vertices, None, None, None)

--- a/src/transformation/to_trimesh/triangle_to_trimesh.rs
+++ b/src/transformation/to_trimesh/triangle_to_trimesh.rs
@@ -7,11 +7,6 @@ impl<N: RealField> ToTriMesh<N> for Triangle<N> {
     type DiscretizationParameter = ();
 
     fn to_trimesh(&self, _: ()) -> TriMesh<N> {
-        TriMesh::new(
-            vec![self.a().clone(), self.b().clone(), self.c().clone()],
-            None,
-            None,
-            None,
-        )
+        TriMesh::new(vec![self.a, self.b, self.c], None, None, None)
     }
 }


### PR DESCRIPTION
This PR combines various small changes that will be needed for Rapier:
- This makes all the shape `Copy`, except for those that can't because of internal allocations.
- If a field of a shape can be public without risking breaking an invariant, it is now.
- This allows the construction of an AABB from a set of points or a single point.
- This adds `AABB::new_invalid()` wich builds an invalid AABB useful for algorithm based on merging multiple aabbs.
- This adds the computation of local support points using the `SupportMap` trait. This reduces the amount of computation when we work in the shape's local-space.