### PR TITLE
Remove `Any` bound from BPPF

### DIFF
--- a/src/pipeline/broad_phase/broad_phase_pair_filter.rs
+++ b/src/pipeline/broad_phase/broad_phase_pair_filter.rs
@@ -1,11 +1,8 @@
 use crate::pipeline::object::CollisionObjectSet;
 use na::RealField;
-use std::any::Any;
 
 /// A signal handler for contact detection.
-pub trait BroadPhasePairFilter<N: RealField, Set: CollisionObjectSet<N>>:
-    Any + Send + Sync
-{
+pub trait BroadPhasePairFilter<N: RealField, Set: CollisionObjectSet<N>>: Send + Sync {
     /// Activate an action for when two objects start or stop to be close to each other.
     fn is_pair_valid(
         &self,

--- a/src/pipeline/world.rs
+++ b/src/pipeline/world.rs
@@ -209,7 +209,7 @@ impl<N: RealField, T> CollisionWorld<N, T> {
     /// collision pairs.
     pub fn set_broad_phase_pair_filter<F>(&mut self, filter: Option<F>)
     where
-        F: BroadPhasePairFilter<N, CollisionObjectSlab<N, T>>,
+        F: BroadPhasePairFilter<N, CollisionObjectSlab<N, T>> + 'static,
     {
         self.pair_filters = filter
             .map(|f| Box::new(f) as Box<dyn BroadPhasePairFilter<N, CollisionObjectSlab<N, T>>>);


### PR DESCRIPTION
An update on #359 to finish the implementation of [nphysics#278][1].

Removing the `Any` bound allows for non-`'static` sets, meaning the filter can use borrowed body and collider sets.

[1]: https://github.com/dimforge/nphysics/pull/278