### PR TITLE
`ConvexHull::try_new`: avoid adding degenerate faces

### DIFF
--- a/src/shape/convex.rs
+++ b/src/shape/convex.rs
@@ -234,7 +234,9 @@ impl<N: RealField> ConvexHull<N> {
                             }
                         }
 
-                        faces.push(new_face);
+                        if new_face.num_vertices_or_edges > 2 {
+                            faces.push(new_face);
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
When simplifying coplanar or concave triangles into a single polygonal
face, sometimes the edge-marching algorithm will create a face with two
vertices, throwing off the Euler characteristic for the resulting solid.
Adding a guard against these degenerate faces keeps the Euler
characteristic correct.