### PR TITLE
Update deps + minor feature additions and fixes

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -35,11 +35,11 @@ smallvec        = "1"
 slab            = "0.4"
 slotmap         = "0.4"
 petgraph        = "0.5"
-simba           = "0.2"
-nalgebra        = "0.22"
-approx          = { version = "0.3", default-features = false }
+simba           = "0.3"
+nalgebra        = "0.23"
+approx          = { version = "0.4", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 rand  = { version = "0.7", default-features = false }
-simba = { version = "0.2", features = [ "partial_fixed_point_support" ] }
+simba = { version = "0.3", features = [ "partial_fixed_point_support" ] }

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -35,9 +35,9 @@ smallvec   = "1"
 slab       = "0.4"
 slotmap    = "0.4"
 petgraph   = "0.5"
-simba      = "0.2"
-nalgebra   = "0.22"
-approx     = { version = "0.3", default-features = false }
+simba      = "0.3"
+nalgebra   = "0.23"
+approx     = { version = "0.4", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 
 [dev-dependencies]

--- a/publish.sh
+++ b/publish.sh
@@ -16,7 +16,7 @@ cd $currdir
 
 ### Publish the 3D version.
 sed 's#\.\./\.\./src#src#g' build/ncollide3d/Cargo.toml > $tmp/Cargo.toml
-sed -i '' -e 's/, path = "\.\.\/ncollide2d\"//g' $tmp/Cargo.toml
+sed -i -e 's/, path = "\.\.\/ncollide2d\"//g' $tmp/Cargo.toml
 cp -r LICENSE README.md $tmp/.
 cd $tmp && cargo publish
 

--- a/src/interpolation/rigid_motion.rs
+++ b/src/interpolation/rigid_motion.rs
@@ -1,7 +1,6 @@
 use na::RealField;
 
 use crate::math::{Isometry, Point, Translation, Vector};
-use crate::utils::IsometryOps;
 
 /// A continuous rigid motion.
 ///

--- a/src/pipeline/narrow_phase/contact_generator/ball_convex_polyhedron_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/ball_convex_polyhedron_manifold_generator.rs
@@ -5,7 +5,6 @@ use crate::query::{
     NeighborhoodGeometry,
 };
 use crate::shape::{Ball, FeatureId, Shape};
-use crate::utils::IsometryOps;
 use na::{RealField, Unit};
 use std::marker::PhantomData;
 

--- a/src/query/closest_points/closest_points_segment_segment.rs
+++ b/src/query/closest_points/closest_points_segment_segment.rs
@@ -47,12 +47,13 @@ pub fn closest_points_segment_segment_with_locations_nD<N, D>(
     seg1: (&Point<N, D>, &Point<N, D>),
     seg2: (&Point<N, D>, &Point<N, D>),
 ) -> (SegmentPointLocation<N>, SegmentPointLocation<N>)
-    where
-        N: RealField,
-        D: DimName,
-        DefaultAllocator: Allocator<N, D>,
+where
+    N: RealField,
+    D: DimName,
+    DefaultAllocator: Allocator<N, D>,
 {
-    let res = closest_points_segment_segment_with_locations_nD_eps(seg1, seg2, N::default_epsilon());
+    let res =
+        closest_points_segment_segment_with_locations_nD_eps(seg1, seg2, N::default_epsilon());
     (res.0, res.1)
 }
 

--- a/src/query/closest_points/mod.rs
+++ b/src/query/closest_points/mod.rs
@@ -15,6 +15,7 @@ pub use self::closest_points_plane_support_map::{
 pub use self::closest_points_segment_segment::{
     closest_points_segment_segment, closest_points_segment_segment_with_locations,
     closest_points_segment_segment_with_locations_nD,
+    closest_points_segment_segment_with_locations_nD_eps,
 };
 pub use self::closest_points_shape_shape::closest_points;
 pub use self::closest_points_support_map_support_map::closest_points_support_map_support_map;

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_support_map_support_map.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_support_map_support_map.rs
@@ -4,7 +4,6 @@ use crate::interpolation::RigidMotion;
 use crate::math::{Isometry, Point, Vector};
 use crate::query::{self, ClosestPoints, TOIStatus, TOI};
 use crate::shape::SupportMap;
-use crate::utils::IsometryOps;
 
 /// Time of impacts between two support-mapped shapes under a rigid motion.
 pub fn nonlinear_time_of_impact_support_map_support_map<N, G1: ?Sized, G2: ?Sized>(

--- a/src/query/point/point_query.rs
+++ b/src/query/point/point_query.rs
@@ -15,10 +15,7 @@ pub struct PointProjection<N: RealField> {
 impl<N: RealField> PointProjection<N> {
     /// Initializes a new `PointProjection`.
     pub fn new(is_inside: bool, point: Point<N>) -> PointProjection<N> {
-        PointProjection {
-            is_inside: is_inside,
-            point: point,
-        }
+        PointProjection { is_inside, point }
     }
 }
 

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -188,6 +188,33 @@ impl<N: RealField> RayCast<N> for ConvexPolygon<N> {
     }
 }
 
+// FIXME: optimize this, we should use the general algorithm for triangles.
+#[cfg(feature = "dim2")]
+impl<N: RealField> RayCast<N> for crate::shape::Triangle<N> {
+    fn toi_and_normal_with_ray(
+        &self,
+        m: &Isometry<N>,
+        ray: &Ray<N>,
+        max_toi: N,
+        solid: bool,
+    ) -> Option<RayIntersection<N>> {
+        let ls_ray = ray.inverse_transform_by(m);
+
+        ray_intersection_with_support_map_with_params(
+            &Isometry::identity(),
+            self,
+            &mut VoronoiSimplex::new(),
+            &ls_ray,
+            max_toi,
+            solid,
+        )
+        .map(|mut res| {
+            res.normal = m * res.normal;
+            res
+        })
+    }
+}
+
 #[allow(unused_variables)]
 impl<N: RealField> RayCast<N> for Segment<N> {
     fn toi_and_normal_with_ray(

--- a/src/query/time_of_impact/time_of_impact.rs
+++ b/src/query/time_of_impact/time_of_impact.rs
@@ -3,7 +3,6 @@ use na::{RealField, Unit};
 use crate::math::{Isometry, Point, Vector};
 use crate::query::{self, TOIDispatcher, Unsupported};
 use crate::shape::{Ball, Plane, Shape};
-use crate::utils::IsometryOps;
 
 /// The status of the time-of-impact computation algorithm.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/query/time_of_impact/time_of_impact_plane_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_plane_support_map.rs
@@ -3,7 +3,6 @@ use na::RealField;
 use crate::math::{Isometry, Vector};
 use crate::query::{Ray, RayCast, TOIStatus, TOI};
 use crate::shape::{Plane, SupportMap};
-use crate::utils::IsometryOps;
 
 /// Time Of Impact of a plane with a support-mapped shape under translational movement.
 pub fn time_of_impact_plane_support_map<N, G: ?Sized>(

--- a/src/shape/capsule.rs
+++ b/src/shape/capsule.rs
@@ -78,7 +78,7 @@ impl<N: RealField> SupportMap<N> for Capsule<N> {
     #[inline]
     fn local_support_point_toward(&self, dir: &Unit<Vector<N>>) -> Point<N> {
         let mut res: Vector<N> = na::zero();
-        res[1] = dir[1].copysign(self.half_height);
+        res[1] = self.half_height.copysign(dir[1]);
         Point::from(res + **dir * self.radius)
     }
 }

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -51,7 +51,7 @@ impl<N: RealField> SupportMap<N> for Cone<N> {
 
         if vres.normalize_mut().is_zero() {
             vres = na::zero();
-            vres[1] = dir[1].copysign(self.half_height);
+            vres[1] = self.half_height.copysign(dir[1]);
         } else {
             vres = vres * self.radius;
             vres[1] = -self.half_height;

--- a/src/shape/convex.rs
+++ b/src/shape/convex.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Point, Vector};
 use crate::shape::{ConvexPolygonalFeature, ConvexPolyhedron, FeatureId, SupportMap};
 use crate::transformation;
-use crate::utils::{self, IsometryOps, SortedPair};
+use crate::utils::{self, SortedPair};
 use na::{self, Point2, Point3, RealField, Unit};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Point, Vector};
 use crate::shape::{ConvexPolygonalFeature, ConvexPolyhedron, FeatureId, SupportMap};
 use crate::transformation;
-use crate::utils::{self, IsometryOps};
+use crate::utils;
 use na::{self, RealField, Unit};
 use std::f64;
 

--- a/src/shape/convex_polygonal_feature2.rs
+++ b/src/shape/convex_polygonal_feature2.rs
@@ -5,7 +5,6 @@ use crate::query::ContactPreprocessor;
 use crate::query::{Contact, ContactPrediction};
 use crate::query::{ContactKinematic, ContactManifold, NeighborhoodGeometry};
 use crate::shape::{FeatureId, Segment, SegmentPointLocation};
-use crate::utils::IsometryOps;
 
 /// A feature (face or vertex) of a 2D convex polygon.
 #[derive(Clone, Debug)]

--- a/src/shape/convex_polygonal_feature3.rs
+++ b/src/shape/convex_polygonal_feature3.rs
@@ -7,7 +7,7 @@ use crate::query::{
     self, Contact, ContactKinematic, ContactManifold, ContactPrediction, NeighborhoodGeometry,
 };
 use crate::shape::{FeatureId, Segment, SegmentPointLocation};
-use crate::utils::{self, IsometryOps};
+use crate::utils;
 
 /// A cache used for polygonal clipping.
 #[derive(Clone)]

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -138,7 +138,7 @@ impl<N: RealField> SupportMap<N> for Cuboid<N> {
         let mut res = self.half_extents;
 
         for i in 0usize..DIM {
-            res[i] = dir[i].copysign(res[i]);
+            res[i] = res[i].copysign(dir[i]);
         }
 
         res.into()

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -56,7 +56,7 @@ impl<N: RealField> SupportMap<N> for Cylinder<N> {
             vres = vres * self.radius;
         }
 
-        vres[1] = dir[1].copysign(self.half_height);
+        vres[1] = self.half_height.copysign(dir[1]);
 
         Point::from(vres)
     }

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -4,7 +4,6 @@ use crate::math::{Isometry, Point, Vector};
 use crate::shape::{ConvexPolygonalFeature, ConvexPolyhedron, FeatureId, SupportMap};
 #[cfg(feature = "dim2")]
 use crate::utils;
-use crate::utils::IsometryOps;
 use na::{self, RealField, Unit};
 use std::f64;
 use std::mem;

--- a/src/shape/shape_impl.rs
+++ b/src/shape/shape_impl.rs
@@ -9,7 +9,6 @@ use crate::shape::{
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{ConvexHull, TriMesh, Triangle};
-use crate::utils::IsometryOps;
 use na::{RealField, Unit};
 
 macro_rules! impl_as_convex_polyhedron (

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -11,7 +11,7 @@ use crate::query::{
 use crate::shape::{
     CompositeShape, DeformableShape, DeformationsType, FeatureId, Segment, Shape, Triangle,
 };
-use crate::utils::{DeterministicState, IsometryOps};
+use crate::utils::DeterministicState;
 use na::{self, Point2, Point3, RealField, Unit};
 use std::collections::{hash_map::Entry, HashMap};
 use std::iter;


### PR DESCRIPTION
This updates all the dependencies of ncollide to their latest versions.
In addition this:
- Fix a bug in the 3D EPA implementation that could cause an assertion failure.
- Add a segment-segment closest point computation that allow specification of the epsilon used for detecting quasi-parallel cases.
- Add a `RayCast` implementation for 2D triangles.
- Fix all the calls to `copysign` after the update to `simba` 0.3.0.