### PR TITLE
add loosen_by_vector and tighten_by_vector, which does the spective operation in each dimension, according to the vector passed in

### DIFF
--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -224,4 +224,32 @@ impl<N: RealField> BoundingVolume<N> for AABB<N> {
             self.maxs + Vector::repeat(-amount),
         )
     }
+
+    #[inline]
+    fn loosen_by_vector(&mut self, amount: Vector<N>){
+        self.mins = self.mins - amount;
+        self.maxs = self.maxs + amount;
+    }
+
+    #[inline]
+    fn loosened_by_vector(&self, amount: Vector<N>) -> Self {
+        AABB {
+            mins: self.mins - amount,
+            maxs: self.maxs + amount,
+        }
+    }
+
+    #[inline]
+    fn tighten_by_vector(&mut self, amount: Vector<N>) {
+        self.mins = self.mins + amount;
+        self.maxs = self.maxs - amount;
+    }
+
+    #[inline]
+    fn tightened_by_vector(&self, amount: Vector<N>) -> Self {
+        AABB {
+            mins: self.mins + amount,
+            maxs: self.maxs - amount,
+        }
+    }
 }

--- a/src/bounding_volume/bounding_volume.rs
+++ b/src/bounding_volume/bounding_volume.rs
@@ -1,4 +1,4 @@
-use crate::math::{Isometry, Point};
+use crate::math::{Isometry, Point, Vector};
 use na::RealField;
 
 /// Traits of objects having a bounding volume.
@@ -45,4 +45,17 @@ pub trait BoundingVolume<N: RealField>: std::fmt::Debug {
 
     /// Creates a new, tightened version, of this bounding volume.
     fn tightened(&self, _: N) -> Self;
+
+    /// Enlarges this bounding volume, by vector in each dimension.
+    fn loosen_by_vector(&mut self, _: Vector<N>);
+
+    /// Creates a new, enlarged version, of this bounding volume, by vector in each dimension.
+    fn loosened_by_vector(&self, _: Vector<N>) -> Self;
+
+    /// Tighten this bounding volume, by vector in each dimension.
+    fn tighten_by_vector(&mut self, _: Vector<N>);
+
+    /// Creates a new, tightened version, of this bounding volume,  by vector in each dimension.
+    fn tightened_by_vector(&self, _: Vector<N>) -> Self;
+
 }


### PR DESCRIPTION
This adds four methods to the bounding_volume trait, and the AABB implementor:

fn loosen_by_vector(&mut self, amount: Vector<N>);
fn loosened_by_vector(&self, amount: Vector<N>) -> Self;
fn tighten_by_vector(&mut self, amount: Vector<N>);
fn tightened_by_vector(&self, amount: Vector<N>) -> Self;

for situations where one only wants to tighten/loosen in a subset of available dimensions.